### PR TITLE
Viewer Improvements

### DIFF
--- a/bats_ai/core/models/spectrogram.py
+++ b/bats_ai/core/models/spectrogram.py
@@ -271,7 +271,7 @@ class Spectrogram(TimeStampedModel, models.Model):
         buf.seek(0)
         img_base64 = base64.b64encode(buf.getvalue()).decode('utf-8')
 
-        return img_base64, starts_, stops_, self.duration
+        return img_base64, starts_, stops_
 
     @property
     def image_np(self):

--- a/bats_ai/core/models/spectrogram.py
+++ b/bats_ai/core/models/spectrogram.py
@@ -271,7 +271,7 @@ class Spectrogram(TimeStampedModel, models.Model):
         buf.seek(0)
         img_base64 = base64.b64encode(buf.getvalue()).decode('utf-8')
 
-        return img_base64, starts_, stops_
+        return img_base64, starts_, stops_, self.duration
 
     @property
     def image_np(self):

--- a/bats_ai/core/views/recording.py
+++ b/bats_ai/core/views/recording.py
@@ -127,12 +127,14 @@ def get_spectrogram_compressed(request: HttpRequest, id: int):
         return {'error': 'Recording not found'}
 
     spectrogram = recording.spectrogram
-    compressed, starts, ends = spectrogram.compressed
+    compressed, starts, ends, duration = spectrogram.compressed
 
     spectro_data = {
         'base64_spectrogram': compressed,
         'spectroInfo': {
             'width': spectrogram.width,
+            'start_time': 0,
+            'end_time': duration,
             'height': spectrogram.height,
             'start_times': starts,
             'end_times': ends,

--- a/bats_ai/core/views/recording.py
+++ b/bats_ai/core/views/recording.py
@@ -127,14 +127,14 @@ def get_spectrogram_compressed(request: HttpRequest, id: int):
         return {'error': 'Recording not found'}
 
     spectrogram = recording.spectrogram
-    compressed, starts, ends, duration = spectrogram.compressed
+    compressed, starts, ends = spectrogram.compressed
 
     spectro_data = {
         'base64_spectrogram': compressed,
         'spectroInfo': {
             'width': spectrogram.width,
             'start_time': 0,
-            'end_time': duration,
+            'end_time': spectrogram.duration,
             'height': spectrogram.height,
             'start_times': starts,
             'end_times': ends,

--- a/client/src/api/api.ts
+++ b/client/src/api/api.ts
@@ -120,6 +120,11 @@ async function getSpectrogram(id: string) {
     return axiosInstance.get<Spectrogram>(`/recording/${id}/spectrogram`);
 }
 
+async function getSpectrogramCompressed(id: string) {
+    return axiosInstance.get<Spectrogram>(`/recording/${id}/spectrogram/compressed`);
+
+}
+
 async function getAnnotations(recordingId: string) {
     return axiosInstance.get<SpectrogramAnnotation[]>(`/recording/${recordingId}/annotations`);
 
@@ -145,6 +150,7 @@ export {
  uploadRecordingFile,
  getRecordings,
  getSpectrogram,
+ getSpectrogramCompressed,
  getSpecies,
  getAnnotations,
  patchAnnotation,

--- a/client/src/components/SpectrogramViewer.vue
+++ b/client/src/components/SpectrogramViewer.vue
@@ -31,7 +31,7 @@ export default defineComponent({
       required: true,
     }
   },
-  emits: ['update:annotation', 'create:annotation', 'selected'],
+  emits: ['update:annotation', 'create:annotation', 'selected', 'geoViewerRef'],
   setup(props, { emit }) {
     const containerRef: Ref<HTMLElement | undefined> = ref();
     const geoJS = useGeoJS();
@@ -43,6 +43,7 @@ export default defineComponent({
       geoJS.initializeViewer(containerRef.value, naturalWidth, naturalHeight);
       geoJS.drawImage(props.image, naturalWidth, naturalHeight);
       initialized.value = true;
+      emit('geoViewerRef', geoJS.getGeoViewer());
     });
 
     const updateAnnotation = async (annotation: SpectrogramAnnotation) => {
@@ -101,7 +102,7 @@ export default defineComponent({
   top: 0;
   bottom: 0;
   z-index: 0;
-  height: 90vh;
+  height: 60vh;
   background-color: black;
 
   display: flex;

--- a/client/src/components/ThumbnailViewer.vue
+++ b/client/src/components/ThumbnailViewer.vue
@@ -1,0 +1,178 @@
+<script lang="ts">
+import { defineComponent, PropType, ref, Ref, watch } from "vue";
+import { SpectroInfo, useGeoJS } from './geoJS/geoJSUtils';
+import { SpectrogramAnnotation } from "../api/api";
+import LayerManager from "./geoJS/LayerManager.vue";
+import geo, { GeoEvent } from "geojs";
+
+export default defineComponent({
+  name: "ThumbnailViewer",
+  components: {
+    LayerManager
+  },
+  props: {
+    image: {
+      type: Object as PropType<HTMLImageElement>,
+      required: true,
+    },
+    spectroInfo: {
+      type: Object as PropType<SpectroInfo | undefined>,
+      default: () => undefined,
+    },
+    annotations: {
+      type: Array as PropType<SpectrogramAnnotation[]>,
+      default: () => [],
+    },
+    selectedId: {
+        type: Number as PropType<number | null>,
+        default: null,
+    },
+    recordingId: {
+      type: String as PropType<string | null>,
+      required: true,
+    },
+    parentGeoViewerRef: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      type: Object as PropType<any>,
+      required: true,
+    }
+  },
+  emits: ['selected'],
+  setup(props, { emit }) {
+    const containerRef: Ref<HTMLElement | undefined> = ref();
+    const geoJS = useGeoJS();
+    const initialized  = ref(false);
+    const polyLayerCreated= ref(false);
+    let downState: {
+      state: any,
+      mouse: any,
+      center: any,
+      rotate: any,
+      zoom:any,
+    }
+
+    const createPolyLayer = () => {
+      const geoViewer = geoJS.getGeoViewer();
+      const featureLayer = geoViewer.value.createLayer('feature', {feattures: ['polygon']});
+      const outlineFeature = featureLayer.createFeature('polygon', {
+        style: {
+          stroke: true,
+          strokeCoor: 'yellow',
+          strokeWidth: 1,
+          fille: false,
+        }
+      });
+      featureLayer.geoOn(geo.event.mouseclick, (evt: GeoEvent) => {
+            props.parentGeoViewerRef.value.center(evt.geo);
+      });
+      featureLayer.geoOn(geo.event.actiondown, (evt) => {
+            downState = {
+                state: evt.state,
+                mouse: evt.mouse,
+                center:  props.parentGeoViewerRef.value.center(),
+                zoom:  props.parentGeoViewerRef.value.zoom(),
+                rotate:  props.parentGeoViewerRef.value.rotation(),
+                //distanceToOutline: geo.util.distanceToPolygon2d(evt.mouse.geo, this._outlineFeature.data()[0]) / this.viewer.unitsPerPixel(this.viewer.zoom())
+            };
+        });
+        featureLayer.geoOn(geo.event.actionmove, (evt: GeoEvent) => {
+            switch (evt.state.action) {
+                case 'overview_pan': {
+                    if (!downState ){ //|| downState.distanceToOutline < -this._panOutlineDistance) {
+                        return;
+                    }
+                    const delta = {
+                        x: evt.mouse.geo.x - downState.mouse.geo.x,
+                        y: evt.mouse.geo.y - downState.mouse.geo.y
+                    };
+                    const center = props.parentGeoViewerRef.value.center();
+                    delta.x -= center.x - downState.center.x;
+                    delta.y -= center.y - downState.center.y;
+                    if (delta.x || delta.y) {
+                      props.parentGeoViewerRef.value.center({
+                            x: center.x + delta.x,
+                            y: center.y + delta.y
+                        });
+                    }
+                }
+                    break;
+            }
+        });
+        polyLayerCreated.value = true;
+    };
+    watch(containerRef, () => {
+      const { naturalWidth, naturalHeight } = props.image;
+      if (containerRef.value)
+      geoJS.initializeViewer(containerRef.value, naturalWidth, naturalHeight, true);
+      geoJS.drawImage(props.image, naturalWidth, naturalHeight);
+      initialized.value = true;
+      if (!polyLayerCreated.value) {
+        createPolyLayer();
+      }
+    });
+
+
+    return {
+      containerRef,
+      geoViewerRef: geoJS.getGeoViewer(),
+      initialized,
+    };
+  },
+});
+</script>
+
+<template>
+  <div class="video-annotator">
+    <div
+      id="spectro"
+      ref="containerRef"
+      class="playback-container"
+    />
+    <layer-manager
+      v-if="initialized"
+      :geo-viewer-ref="geoViewerRef"
+      :spectro-info="spectroInfo"
+      :annotations="annotations"
+      :selected-id="selectedId"
+      @selected="$emit('selected',$event)"
+    />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.video-annotator {
+  position: relative;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  z-index: 0;
+  height: 20vh;
+  background-color: black;
+  border: 2px solid white;
+
+  display: flex;
+  flex-direction: column;
+  .geojs-map {
+    margin:2px;
+    &.geojs-map:focus {
+      outline: none;
+    }  
+  }
+
+  .playback-container {
+    flex: 1;
+  }
+  .loadingSpinnerContainer {
+    z-index: 20;
+    margin: 0;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    -ms-transform: translate(-50%, -50%);
+    transform: translate(-50%, -50%);
+  }
+  .geojs-map.annotation-input {
+    cursor: inherit;
+  }
+}</style>

--- a/client/src/components/geoJS/geoJSUtils.ts
+++ b/client/src/components/geoJS/geoJSUtils.ts
@@ -1,220 +1,343 @@
-
 import { ref, Ref } from "vue";
 import geo from "geojs";
 
 const useGeoJS = () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const geoViewer: Ref<any> = ref();
+  const container: Ref<HTMLElement | undefined> = ref();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let quadFeature: any;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const geoViewer: Ref<any> = ref();
-    const container: Ref<HTMLElement| undefined> = ref();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let quadFeature: any;
+  const thumbnail = ref(false);
 
-    const thumbnail = ref(false);
+  let originalBounds = {
+    left: 0,
+    top: 0,
+    bottom: 1,
+    right: 1,
+  };
 
-    let originalBounds = {
-        left: 0,
-        top: 0,
-        bottom: 1,
-        right: 1,
+  const getGeoViewer = () => {
+    return geoViewer;
+  };
+
+  const initializeViewer = (
+    sourceContainer: HTMLElement,
+    width: number,
+    height: number,
+    thumbanilVal = false
+  ) => {
+    thumbnail.value = thumbanilVal;
+    container.value = sourceContainer;
+    const params = geo.util.pixelCoordinateParams(container.value, width, height);
+    if (!container.value) {
+      return;
+    }
+    geoViewer.value = geo.map(params.map);
+    resetMapDimensions(width, height);
+    const interactorOpts = geoViewer.value.interactor().options();
+    interactorOpts.keyboard.focusHighlight = false;
+    interactorOpts.keyboard.actions = {};
+    interactorOpts.click.cancelOnMove = 5;
+
+    interactorOpts.actions = [
+      interactorOpts.actions[0],
+      // The action below is needed to have GeoJS use the proper handler
+      // with cancelOnMove for right clicks
+      {
+        action: geo.geo_action.select,
+        input: { right: true },
+        name: "button edit",
+        owner: "geo.MapInteractor",
+      },
+      // The action below adds middle mouse button click to panning
+      // It allows for panning while in the process of polygon editing or creation
+      {
+        action: geo.geo_action.pan,
+        input: "middle",
+        modifiers: { shift: false, ctrl: false },
+        owner: "geo.mapInteractor",
+        name: "button pan",
+      },
+      interactorOpts.actions[2],
+      interactorOpts.actions[6],
+      interactorOpts.actions[7],
+      interactorOpts.actions[8],
+      interactorOpts.actions[9],
+    ];
+    // Set > 2pi to disable rotation
+    interactorOpts.zoomrotateMinimumRotation = 7;
+    interactorOpts.zoomAnimation = {
+      enabled: false,
     };
-
-    const getGeoViewer = () => {
-        return geoViewer;
+    interactorOpts.momentum = {
+      enabled: false,
     };
-
-    const initializeViewer = (sourceContainer: HTMLElement, width: number, height: number, thumbanilVal=false) => {
-        thumbnail.value = thumbanilVal;
-        container.value = sourceContainer;
-        const params = geo.util.pixelCoordinateParams(
-        container.value,
-        width,
-        height
-        );
-        if (!container.value) {
-            return;
-        }
-        geoViewer.value = geo.map(params.map);
-        resetMapDimensions(width, height);
-        const interactorOpts = geoViewer.value.interactor().options();
-        interactorOpts.keyboard.focusHighlight = false;
-        interactorOpts.keyboard.actions = {};
-        interactorOpts.click.cancelOnMove = 5;
-
-        interactorOpts.actions = [
-        interactorOpts.actions[0],
-        // The action below is needed to have GeoJS use the proper handler
-        // with cancelOnMove for right clicks
+    interactorOpts.wheelScaleY = 0.2;
+    if (thumbnail.value) {
+      interactorOpts.actions = [
         {
-            action: geo.geo_action.select,
-            input: { right: true },
-            name: "button edit",
-            owner: "geo.MapInteractor",
+          action: "overview_pan",
+          input: "left",
+          modifiers: { shift: false, ctrl: false },
+          name: "button pan",
         },
-        // The action below adds middle mouse button click to panning
-        // It allows for panning while in the process of polygon editing or creation
-        {
-            action: geo.geo_action.pan,
-            input: "middle",
-            modifiers: { shift: false, ctrl: false },
-            owner: "geo.mapInteractor",
-            name: "button pan",
-        },
-        interactorOpts.actions[2],
-        interactorOpts.actions[6],
-        interactorOpts.actions[7],
-        interactorOpts.actions[8],
-        interactorOpts.actions[9],
-        ];
-        // Set > 2pi to disable rotation
-        interactorOpts.zoomrotateMinimumRotation = 7;
-        interactorOpts.zoomAnimation = {
-        enabled: false,
-        };
-        interactorOpts.momentum = {
-        enabled: false,
-        };
-        interactorOpts.wheelScaleY = 0.2;
-        if (thumbnail.value) {
-          interactorOpts.actions = [{
-                action: 'overview_pan',
-                input: 'left',
-                modifiers: {shift: false, ctrl: false},
-                name: 'button pan'
-            }];
-        }
-        geoViewer.value.interactor().options(interactorOpts);
-        geoViewer.value.bounds({
-            left: 0,
-            top: 0,
-            bottom: height,
-            right: width,
-        });
+      ];
+    }
+    geoViewer.value.interactor().options(interactorOpts);
+    geoViewer.value.bounds({
+      left: 0,
+      top: 0,
+      bottom: height,
+      right: width,
+    });
 
-        const quadFeatureLayer = geoViewer.value.createLayer("feature", {
-        features: ["quad"],
-        autoshareRenderer: false,
-        renderer: "canvas",
-        });
-        quadFeature = quadFeatureLayer.createFeature("quad");
-    };
+    const quadFeatureLayer = geoViewer.value.createLayer("feature", {
+      features: ["quad"],
+      autoshareRenderer: false,
+      renderer: "canvas",
+    });
+    quadFeature = quadFeatureLayer.createFeature("quad");
+  };
 
-    const drawImage =  (image: HTMLImageElement, width = image.width, height = image.height) => {
-        if (quadFeature) {
-            quadFeature
-                .data([
-                {
-                    ul: { x: 0, y: 0 },
-                    lr: { x: width, y: height },
-                    image: image,
-                },
-                ])
-                .draw();
-        }
-        resetMapDimensions(width, height);
-    };
-    const resetZoom = () => {
-      const mapWidth = geoViewer.value.camera().viewport.width;
-      const bounds = !thumbnail.value ? {left: 0, top: 0, right: mapWidth, bottom: originalBounds.bottom } : originalBounds;
-        const zoomAndCenter = geoViewer.value.zoomAndCenterFromBounds(
-          bounds, 0,
-        );
-        geoViewer.value.zoom(zoomAndCenter.zoom);
-        geoViewer.value.center(zoomAndCenter.center);
-    };
-  
-    const resetMapDimensions = ( width: number, height: number, margin = 0.3) => {
-        // Want the height to be the main view and whe width to be  relative to the width of the geo.amp
-        geoViewer.value.bounds({
-            left: 0,
-            top: 0,
-            bottom: height,
-            right: width,
-          });
-          const params = geo.util.pixelCoordinateParams(
-            container.value, width, height, width, height,
-          );
-          const { right, bottom } = params.map.maxBounds;
-          originalBounds = params.map.maxBounds;
-          geoViewer.value.maxBounds({
-            left: 0 - (right * margin),
-            top: 0 - (bottom * margin),
-            right: right * (1 + margin),
-            bottom: bottom * (1 + margin),
-          });
-          geoViewer.value.zoomRange({
-            // do not set a min limit so that bounds clamping determines min
-              min: -Infinity,
-              // 4x zoom max
-              max: 4,
-          });
-            geoViewer.value.clampBoundsX(true);
-            geoViewer.value.clampBoundsY(true);
-            geoViewer.value.clampZoom(true);
-    
-          resetZoom();    
-    };
+  const drawImage = (image: HTMLImageElement, width = image.width, height = image.height) => {
+    if (quadFeature) {
+      quadFeature
+        .data([
+          {
+            ul: { x: 0, y: 0 },
+            lr: { x: width, y: height },
+            image: image,
+          },
+        ])
+        .draw();
+    }
+    resetMapDimensions(width, height);
+  };
+  const resetZoom = () => {
+    const { width: mapWidth } = geoViewer.value.camera().viewport;
 
-    return {
-        getGeoViewer,
-        initializeViewer,
-        drawImage,
-        resetMapDimensions,
-        resetZoom
-    };
+    const bounds = !thumbnail.value
+      ? { left: 0, top: 0, right: mapWidth, bottom: originalBounds.bottom }
+      : originalBounds;
+    const zoomAndCenter = geoViewer.value.zoomAndCenterFromBounds(bounds, 0);
+    geoViewer.value.zoom(zoomAndCenter.zoom);
+    geoViewer.value.center(zoomAndCenter.center);
+  };
+
+  const resetMapDimensions = (width: number, height: number, margin = 0.3) => {
+    // Want the height to be the main view and whe width to be  relative to the width of the geo.amp
+    geoViewer.value.bounds({
+      left: 0,
+      top: 0,
+      bottom: height,
+      right: width,
+    });
+    const params = geo.util.pixelCoordinateParams(container.value, width, height, width, height);
+    const { right, bottom } = params.map.maxBounds;
+    originalBounds = params.map.maxBounds;
+    geoViewer.value.maxBounds({
+      left: 0 - right * margin,
+      top: 0 - bottom * margin,
+      right: right * (1 + margin),
+      bottom: bottom * (1 + margin),
+    });
+    geoViewer.value.zoomRange({
+      // do not set a min limit so that bounds clamping determines min
+      min: -Infinity,
+      // 4x zoom max
+      max: 4,
+    });
+    geoViewer.value.clampBoundsX(true);
+    geoViewer.value.clampBoundsY(true);
+    geoViewer.value.clampZoom(true);
+
+    resetZoom();
+  };
+
+  return {
+    getGeoViewer,
+    initializeViewer,
+    drawImage,
+    resetMapDimensions,
+    resetZoom,
+  };
 };
 
 import { SpectrogramAnnotation } from "../../api/api";
 
 export interface SpectroInfo {
-    width: number;
-    height: number;
-    start_time: number;
-    end_time: number;
-    low_freq: number;
-    high_freq: number;
+  width: number;
+  height: number;
+  start_time: number;
+  end_time: number;
+  start_times?: number[];
+  end_times?: number[];
+  low_freq: number;
+  high_freq: number;
 }
-function spectroToGeoJSon(annotation: SpectrogramAnnotation, spectroInfo: SpectroInfo): GeoJSON.Polygon  {
-    //scale pixels to time and frequency ranges
-    const widthScale =   spectroInfo.width / (spectroInfo.end_time - spectroInfo.start_time);
+
+function spectroToGeoJSon(
+  annotation: SpectrogramAnnotation,
+  spectroInfo: SpectroInfo
+): GeoJSON.Polygon {
+  //scale pixels to time and frequency ranges
+  if (spectroInfo.start_times === undefined || spectroInfo.end_times === undefined) {
+    const widthScale = spectroInfo.width / (spectroInfo.end_time - spectroInfo.start_time);
     const heightScale = spectroInfo.height / (spectroInfo.high_freq - spectroInfo.low_freq);
     // Now we remap our annotation to pixel coordinates
-    const low_freq = spectroInfo.height - (annotation.low_freq * heightScale);
-    const high_freq = spectroInfo.height - (annotation.high_freq * heightScale);
+    const low_freq =
+      spectroInfo.height - (annotation.low_freq - spectroInfo.low_freq) * heightScale;
+    const high_freq =
+      spectroInfo.height - (annotation.high_freq - spectroInfo.low_freq) * heightScale;
     const start_time = annotation.start_time * widthScale;
     const end_time = annotation.end_time * widthScale;
     return {
-        type: 'Polygon',
-        coordinates: [  
-            [
-              [start_time, low_freq],
-              [start_time, high_freq],
-              [end_time, high_freq],
-              [end_time, low_freq],
-              [start_time, low_freq],
-            ],
-          ],
-      
+      type: "Polygon",
+      coordinates: [
+        [
+          [start_time, low_freq],
+          [start_time, high_freq],
+          [end_time, high_freq],
+          [end_time, low_freq],
+          [start_time, low_freq],
+        ],
+      ],
     };
-}
+  } else if (spectroInfo.start_times && spectroInfo.end_times) {
+    // Compressed Spectro has different conversion
+    // Find what section the annotation is in
+    const start = annotation.start_time;
+    const end = annotation.end_time;
+    const { start_times, end_times } = spectroInfo;
+    const lengths = start_times.length === end_times.length ? start_times.length : 0;
+    let foundIndex = -1;
+    for (let i = 0; i < lengths; i += 1) {
+      if (
+        start_times[i] < start &&
+        start < end_times[i] &&
+        end < end_times[i] &&
+        end > start_times[i]
+      ) {
+        foundIndex = i;
+        break;
+      }
+    }
+    // We need to build the length of times to pixel size for the time spaces before the annotation
+    const widthScale = spectroInfo.width / (spectroInfo.end_time - spectroInfo.start_time);
+    let pixelAdd = 0;
+    for (let i = 0; i < foundIndex; i += 1) {
+      pixelAdd += (end_times[i] - start_times[i]) * widthScale;
+    }
+    const heightScale = spectroInfo.height / (spectroInfo.high_freq - spectroInfo.low_freq);
+    // Now we remap our annotation to pixel coordinates
+    const low_freq =
+      spectroInfo.height - (annotation.low_freq - spectroInfo.low_freq) * heightScale;
+    const high_freq =
+      spectroInfo.height - (annotation.high_freq - spectroInfo.low_freq) * heightScale;
+    const start_time = pixelAdd + (annotation.start_time - start_times[foundIndex]) * widthScale;
+    const end_time = pixelAdd + (annotation.end_time - start_times[foundIndex]) * widthScale;
 
-/* beginning at bottom left, rectangle is defined clockwise */
-function geojsonToSpectro(geojson: GeoJSON.Feature<GeoJSON.Polygon>, spectroInfo: SpectroInfo): { start_time: number, end_time: number, low_freq: number, high_freq: number} {
-  const coords = geojson.geometry.coordinates[0];
-  const widthScale =  spectroInfo.width / (spectroInfo.end_time - spectroInfo.start_time);
-  const heightScale = spectroInfo.height / (spectroInfo.high_freq - spectroInfo.low_freq);
-  const start_time = Math.round(coords[1][0] / widthScale);
-  const end_time = Math.round(coords[3][0] / widthScale);
-  const low_freq = Math.round(spectroInfo.high_freq - (coords[1][1]) / heightScale);
-  const high_freq = Math.round(spectroInfo.high_freq - (coords[3][1]) / heightScale);
+    return {
+      type: "Polygon",
+      coordinates: [
+        [
+          [start_time, low_freq],
+          [start_time, high_freq],
+          [end_time, high_freq],
+          [end_time, low_freq],
+          [start_time, low_freq],
+        ],
+      ],
+    };
+  }
   return {
-    start_time,
-    end_time,
-    low_freq,
-    high_freq
+    type: "Polygon",
+    coordinates: [
+      [
+        [0, 0],
+        [0, 0],
+        [0, 0],
+        [0, 0],
+        [0, 0],
+      ],
+    ],
   };
 }
 
+/* beginning at bottom left, rectangle is defined clockwise */
+function geojsonToSpectro(
+  geojson: GeoJSON.Feature<GeoJSON.Polygon>,
+  spectroInfo: SpectroInfo
+): { error?: string; start_time: number; end_time: number; low_freq: number; high_freq: number } {
+  const coords = geojson.geometry.coordinates[0];
+  if (spectroInfo.start_times === undefined && spectroInfo.end_times === undefined) {
+    const widthScale = spectroInfo.width / (spectroInfo.end_time - spectroInfo.start_time);
+    const heightScale = spectroInfo.height / (spectroInfo.high_freq - spectroInfo.low_freq);
+    const start_time = Math.round(coords[1][0] / widthScale);
+    const end_time = Math.round(coords[3][0] / widthScale);
+    const high_freq = Math.round(spectroInfo.high_freq - coords[1][1] / heightScale);
+    const low_freq = Math.round(spectroInfo.high_freq - coords[3][1] / heightScale);
+    return {
+      start_time,
+      end_time,
+      low_freq,
+      high_freq,
+    };
+  } else if (spectroInfo.start_times && spectroInfo.end_times) {
+    // first need to map the X positions to times based on the start/endtimes
+    const start = coords[1][0];
+    const end = coords[3][0];
+    const { start_times, end_times } = spectroInfo;
+    const timeToPixels = spectroInfo.width / (spectroInfo.end_time - spectroInfo.start_time);
+    let additivePixels = 0;
+    let start_time = -1;
+    let end_time = -1;
+    for (let i = 0; i < start_times.length; i += 1) {
+      // convert the start/end time to a pixel
+      const nextPixels = (end_times[i] - start_times[i]) * timeToPixels;
+      if (start > additivePixels && end < additivePixels + nextPixels) {
+        // Found the location for time markers
+        // We need to remap pixels back to milliseconds
+        const lowPixels = start - additivePixels;
+        const highPixels = end - additivePixels;
+        const lowTime = start_times[i] + lowPixels / timeToPixels;
+        const highTime = start_times[i] + highPixels / timeToPixels;
+        start_time = Math.round(lowTime);
+        end_time = Math.round(highTime);
+        break;
+      }
+      additivePixels += nextPixels;
+    }
+    const heightScale = spectroInfo.height / (spectroInfo.high_freq - spectroInfo.low_freq);
+    const high_freq = Math.round(spectroInfo.high_freq - coords[1][1] / heightScale);
+    const low_freq = Math.round(spectroInfo.high_freq - coords[3][1] / heightScale);
+    if (start_time === -1 || end_time === -1) {
+      // the time spreads across multiple pulses and isn't allowed;
+      return {
+        error:
+          "Start or End Time spread across pusles.  This is not allowed in compressed annotations",
+        start_time,
+        end_time,
+        low_freq,
+        high_freq,
+      };
+    }
+    return {
+      start_time,
+      end_time,
+      low_freq,
+      high_freq,
+    };
+  }
+  return {
+    error: "Spectrogram Info didn't match a regular or compressed view",
+    start_time: 0,
+    end_time: 0,
+    low_freq: 0,
+    high_freq: 0,
+  };
+}
 
 /**
  * This will take the current geoJSON Coordinates for a rectangle and reorder it
@@ -241,10 +364,4 @@ function reOrdergeoJSON(coords: GeoJSON.Position[]) {
   ];
 }
 
-
-export {
-  spectroToGeoJSon,
-  geojsonToSpectro,
-  reOrdergeoJSON,
-  useGeoJS,
-};
+export { spectroToGeoJSon, geojsonToSpectro, reOrdergeoJSON, useGeoJS };

--- a/client/src/components/geoJS/geoJSUtils.ts
+++ b/client/src/components/geoJS/geoJSUtils.ts
@@ -9,6 +9,9 @@ const useGeoJS = () => {
     const container: Ref<HTMLElement| undefined> = ref();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let quadFeature: any;
+
+    const thumbnail = ref(false);
+
     let originalBounds = {
         left: 0,
         top: 0,
@@ -20,7 +23,8 @@ const useGeoJS = () => {
         return geoViewer;
     };
 
-    const initializeViewer = (sourceContainer: HTMLElement, width: number, height: number) => {
+    const initializeViewer = (sourceContainer: HTMLElement, width: number, height: number, thumbanilVal=false) => {
+        thumbnail.value = thumbanilVal;
         container.value = sourceContainer;
         const params = geo.util.pixelCoordinateParams(
         container.value,
@@ -71,6 +75,14 @@ const useGeoJS = () => {
         enabled: false,
         };
         interactorOpts.wheelScaleY = 0.2;
+        if (thumbnail.value) {
+          interactorOpts.actions = [{
+                action: 'overview_pan',
+                input: 'left',
+                modifiers: {shift: false, ctrl: false},
+                name: 'button pan'
+            }];
+        }
         geoViewer.value.interactor().options(interactorOpts);
         geoViewer.value.bounds({
             left: 0,
@@ -102,14 +114,17 @@ const useGeoJS = () => {
         resetMapDimensions(width, height);
     };
     const resetZoom = () => {
+      const mapWidth = geoViewer.value.camera().viewport.width;
+      const bounds = !thumbnail.value ? {left: 0, top: 0, right: mapWidth, bottom: originalBounds.bottom } : originalBounds;
         const zoomAndCenter = geoViewer.value.zoomAndCenterFromBounds(
-          originalBounds, 0,
+          bounds, 0,
         );
         geoViewer.value.zoom(zoomAndCenter.zoom);
         geoViewer.value.center(zoomAndCenter.center);
     };
   
     const resetMapDimensions = ( width: number, height: number, margin = 0.3) => {
+        // Want the height to be the main view and whe width to be  relative to the width of the geo.amp
         geoViewer.value.bounds({
             left: 0,
             top: 0,
@@ -132,7 +147,7 @@ const useGeoJS = () => {
               min: -Infinity,
               // 4x zoom max
               max: 4,
-            });
+          });
             geoViewer.value.clampBoundsX(true);
             geoViewer.value.clampBoundsY(true);
             geoViewer.value.clampZoom(true);

--- a/client/src/components/geoJS/layers/rectangleLayer.ts
+++ b/client/src/components/geoJS/layers/rectangleLayer.ts
@@ -143,7 +143,7 @@ export default class RectangleLayer {
     return {
       ...{
         strokeColor: "black",
-        strokeWidth: 4.0,
+        strokeWidth: 2.0,
         antialiasing: 0,
         stroke: true,
         uniformPolygon: true,

--- a/client/src/views/Spectrogram.vue
+++ b/client/src/views/Spectrogram.vue
@@ -5,6 +5,7 @@ import SpectrogramViewer from '../components/SpectrogramViewer.vue';
 import { SpectroInfo } from '../components/geoJS/geoJSUtils';
 import AnnotationList from '../components/AnnotationList.vue';
 import AnnotationEditor from '../components/AnnotationEditor.vue';
+import ThumbnailViewer from '../components/ThumbnailViewer.vue';
 
 export default defineComponent({
   name: "Spectrogram",
@@ -12,6 +13,7 @@ export default defineComponent({
     SpectrogramViewer,
     AnnotationList,
     AnnotationEditor,
+    ThumbnailViewer,
   },
   props: {
     id: {
@@ -56,6 +58,11 @@ export default defineComponent({
       return null;
     });
     onMounted(() => loadData());
+    const parentGeoViewerRef: Ref<any> = ref(null);
+    const setParentGeoViewer = (data: any) => {
+      parentGeoViewerRef.value = data;
+
+    }
     return { 
       loadedImage,
       image,
@@ -64,8 +71,10 @@ export default defineComponent({
       selectedId,
       setSelection,
       getAnnotationsList,
+      setParentGeoViewer,
       speciesList,
       selectedAnnotation,
+      parentGeoViewerRef,
     };
   },
 });
@@ -83,6 +92,17 @@ export default defineComponent({
         :selected-id="selectedId"
         @selected="setSelection($event)"
         @create:annotation="getAnnotationsList($event)"
+        @geo-viewer-ref="setParentGeoViewer($event)"
+      />
+      <thumbnail-viewer
+        v-if="loadedImage && parentGeoViewerRef"
+        :image="image"
+        :spectro-info="spectroInfo"
+        :recording-id="id"
+        :annotations="annotations"
+        :selected-id="selectedId"
+        :parent-geo-viewer-ref="parentGeoViewerRef"
+        @selected="setSelection($event)"
       />
     </v-col>
     <v-col style="max-width:300px">


### PR DESCRIPTION
resolves #17 
- [x] Change Default Zoom to use pixel width of the canvas instead of zooming the whole item
- [x] Create thumbnail view which is the whole width of the spectrogram (may want to stretch some of it vertically to provide a better view of what is happening
- [x] Adding Dragging tool to quickly drag long the length of the Spectrogram
- [x] Add outline to show current camera view
- [x] Swap between regular and compressed views from the client


Still left for improvements: 

https://github.com/Kitware/batai/assets/61746913/6e7ef1f0-e957-4aff-9237-fcae4c4ac7c7

