### PR TITLE
upload metadata, scaling annotations, duration labels

### DIFF
--- a/client/src/components/AnnotationList.vue
+++ b/client/src/components/AnnotationList.vue
@@ -129,6 +129,7 @@ export default defineComponent({
               <v-row>
                 <v-col class="annotation-time">
                   <span>{{ annotation.start_time }}-{{ annotation.end_time }}ms</span>
+                  <span class="pl-2"><b>({{ annotation.end_time - annotation.start_time }}ms)</b></span>
                 </v-col>
                 <v-col class="annotation-freq">
                   <span>{{ (annotation.low_freq/1000).toFixed(1) }}-{{ (annotation.high_freq/1000).toFixed() }}Khz </span>
@@ -184,6 +185,7 @@ export default defineComponent({
               <v-row>
                 <v-col class="annotation-time">
                   <span>{{ annotation.start_time }}-{{ annotation.end_time }}ms</span>
+                  <span class="pl-2"><b>({{ annotation.end_time - annotation.start_time }}ms)</b></span>
                 </v-col>
                 <v-col class="annotation-time">
                   <b>Type:</b><span>{{ annotation.type }}</span>

--- a/client/src/components/HelpSystem.vue
+++ b/client/src/components/HelpSystem.vue
@@ -130,10 +130,24 @@ export default defineComponent({
                       color=""
                       variant="flat"
                     >
+                      <v-icon>mdi-arrow-left-right</v-icon>
                       <h3>ms</h3>
                     </v-btn>
                   </v-col>
-                  <v-col>Toggle millisecond/timing labels</v-col>
+                  <v-col>Toggle millisecond/timing endpoint labels</v-col>
+                </v-row>
+                <v-row>
+                  <v-col>
+                    <v-btn
+                      size="35"
+                      color=""
+                      variant="flat"
+                    >
+                      <v-icon>mdi-arrow-expand-horizontal</v-icon>
+                      <h3>ms</h3>
+                    </v-btn>
+                  </v-col>
+                  <v-col>Toggle millisecond/timing duration labels</v-col>
                 </v-row>
                 <v-row>
                   <v-col>

--- a/client/src/components/TemporalList.vue
+++ b/client/src/components/TemporalList.vue
@@ -78,6 +78,7 @@ export default defineComponent({
         <v-row>
           <v-col class="annotation-time">
             <span>{{ annotation.start_time }}-{{ annotation.end_time }}ms</span>
+            <span class="pl-2"><b>({{ annotation.end_time - annotation.start_time }}ms)</b></span>
           </v-col>
         </v-row>
         <v-row

--- a/client/src/components/UploadRecording.vue
+++ b/client/src/components/UploadRecording.vue
@@ -42,7 +42,7 @@ export default defineComponent({
     const errorText = ref('');
     const progressState = ref('');
     const recordedDate = ref(props.editing ? props.editing.date : new Date().toISOString().split('T')[0]); // YYYY-MM-DD Time
-    const recordedTime = ref(props.editing ? props.editing.time : getCurrentTime()); // HHMMSS
+    const recordedTime = ref(props.editing ? props.editing.time.replaceAll(':','') : getCurrentTime()); // HHMMSS
     const uploadProgress = ref(0);
     const name = ref(props.editing ? props.editing.name : '');
     const equipment = ref(props.editing ? props.editing.equipment : '');
@@ -53,18 +53,31 @@ export default defineComponent({
     const gridCellId: Ref<number | undefined> = ref();
     const publicVal = ref(props.editing ? props.editing.public : false);
     const autoFill = async (filename: string) => {
-      const parts = filename.split("_");
+
+      const regexPattern = /^(\d+)_(.+)_(\d{8})_(\d{6})(?:_(.*))?$/;
+
+      // Match the file name against the regular expression
+      const match = filename.match(regexPattern);
+
+      // If there's no match, return null
+      if (!match) {
+          return null;
+      }
+
+      // Extract the matched groups
+      const cellId = match[1];
+      const labelName = match[2];
+      const date = match[3];
+      const timestamp = match[4];
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const extraData = match[5] || null; // Additional data after the required parts
 
       // Extracting individual components
-      const cellId = parts[0];
-      const quadrant = parts[1];
-      const date = parts[2];
-      const timestamp = parts[3];
       if (cellId) {
         gridCellId.value = parseInt(cellId, 10);
         let updatedQuadrant;
-        if (['SW', 'NE', 'NW', 'SE'].includes(quadrant)) {
-          updatedQuadrant = quadrant as 'SW' | 'NE' | 'NW' | 'SE' | undefined;
+        if (['SW', 'NE', 'NW', 'SE'].includes(labelName)) {
+          updatedQuadrant = labelName as 'SW' | 'NE' | 'NW' | 'SE' | undefined;
         }
         const { latitude: lat , longitude: lon } = (await getCellLocation(gridCellId.value, updatedQuadrant)).data;
         if (lat && lon) {

--- a/client/src/components/geoJS/LayerManager.vue
+++ b/client/src/components/geoJS/LayerManager.vue
@@ -244,7 +244,7 @@ export default defineComponent({
           }
         } else if (creating) {
           if (geoJSON && props.spectroInfo) {
-            const conversionResult = geojsonToSpectro(geoJSON, props.spectroInfo);
+            const conversionResult = geojsonToSpectro(geoJSON, props.spectroInfo, props.scaledWidth, props.scaledHeight);
 
             if (conversionResult.error) {
               displayError.value = true;
@@ -332,7 +332,12 @@ export default defineComponent({
           legendLayer.setGridEnabled(false);
         }
         legendLayer.redraw();
-        if (layerVisibility.value.includes("time")) {
+        if (layerVisibility.value.includes("time") || layerVisibility.value.includes('duration')) {
+          if (layerVisibility.value.includes("time")) {
+            timeLayer.displayDuration = false;
+          } else {
+            timeLayer.displayDuration = true;
+          }
           timeLayer.formatData(annotations, temporalAnnotations);
           timeLayer.redraw();
         } else {

--- a/client/src/use/useState.ts
+++ b/client/src/use/useState.ts
@@ -6,7 +6,7 @@ import { OtherUserAnnotations, Recording, SpectrogramAnnotation, SpectrogramTemp
 const annotationState: Ref<AnnotationState> = ref("");
 const creationType: Ref<'pulse' | 'sequence'> = ref("pulse");
 type LayersVis = "time" | "freq" | "species" | "grid" | 'temporal' | 'duration';
-const layerVisibility: Ref<LayersVis[]> = ref(['temporal', 'species', 'time', 'freq']);
+const layerVisibility: Ref<LayersVis[]> = ref(['temporal', 'species', 'duration', 'freq']);
 const colorScale: Ref<d3.ScaleOrdinal<string, string, never> | undefined> = ref();
 const selectedUsers: Ref<string[]> = ref([]);
 const currentUser: Ref<string> = ref('');

--- a/client/src/use/useState.ts
+++ b/client/src/use/useState.ts
@@ -5,7 +5,7 @@ import { OtherUserAnnotations, Recording, SpectrogramAnnotation, SpectrogramTemp
 
 const annotationState: Ref<AnnotationState> = ref("");
 const creationType: Ref<'pulse' | 'sequence'> = ref("pulse");
-type LayersVis = "time" | "freq" | "species" | "grid" | 'temporal';
+type LayersVis = "time" | "freq" | "species" | "grid" | 'temporal' | 'duration';
 const layerVisibility: Ref<LayersVis[]> = ref(['temporal', 'species', 'time', 'freq']);
 const colorScale: Ref<d3.ScaleOrdinal<string, string, never> | undefined> = ref();
 const selectedUsers: Ref<string[]> = ref([]);
@@ -35,6 +35,14 @@ export default function useState() {
     } else {
       // If the value is present, remove it
       clone.splice(index, 1);
+    }
+    if (value === 'time' && clone.includes('duration')) {
+      const durationInd = layerVisibility.value.indexOf('duration');
+      clone.splice(durationInd, 1);
+    }
+    if (value === 'duration' && clone.includes('time')) {
+      const timeInd = layerVisibility.value.indexOf('time');
+      clone.splice(timeInd, 1);
     }
     layerVisibility.value = clone;
   }

--- a/client/src/views/Recordings.vue
+++ b/client/src/views/Recordings.vue
@@ -203,7 +203,7 @@ export default defineComponent({
         :headers="headers"
         :items="recordingList"
         density="compact"
-        class="elevation-1"
+        class="elevation-1 my-recordings"
       >
         <template #item.edit="{ item }">
           <v-icon @click="editRecording(item.raw)">
@@ -277,6 +277,7 @@ export default defineComponent({
             mdi-close
           </v-icon>
         </template>
+        <template #bottom />
       </v-data-table>
     </v-card-text>
     <v-dialog
@@ -304,7 +305,7 @@ export default defineComponent({
         :headers="sharedHeaders"
         :items="sharedList"
         density="compact"
-        class="elevation-1"
+        class="elevation-1 shared-recordings"
       >
         <template #item.name="{ item }">
           <router-link
@@ -367,7 +368,20 @@ export default defineComponent({
             mdi-close
           </v-icon>
         </template>
+        <template #bottom />
       </v-data-table>
     </v-card-text>
   </v-card>
 </template>
+
+<style scoped>
+.my-recordings {
+  height: 40vh;
+  max-height: 40vh;
+  overflow-y:scroll;
+}
+.shared-recordings {
+  height: 40vh;
+  max-height: 40vh;
+}
+</style>

--- a/client/src/views/Spectrogram.vue
+++ b/client/src/views/Spectrogram.vue
@@ -299,10 +299,26 @@ export default defineComponent({
                   :color="layerVisibility.includes('time') ? 'blue' : ''"
                   @click="toggleLayerVisibility('time')"
                 >
-                  <h3>ms</h3>
+                  <v-icon>mdi-arrow-left-right</v-icon>
+                  <h4>ms</h4>
                 </v-btn>
               </template>
-              <span> Turn Time Label On/Off</span>
+              <span> Turn Time Endpoint Labels On/Off</span>
+            </v-tooltip>
+            <v-tooltip bottom>
+              <template #activator="{ props: subProps }">
+                <v-btn
+                  v-bind="subProps"
+                  size="35"
+                  class="mr-5 mt-5"
+                  :color="layerVisibility.includes('duration') ? 'blue' : ''"
+                  @click="toggleLayerVisibility('duration')"
+                >
+                  <v-icon>mdi-arrow-expand-horizontal</v-icon>
+                  <h4>ms</h4>
+                </v-btn>
+              </template>
+              <span> Turn Time Duration Labels On/Off</span>
             </v-tooltip>
             <v-tooltip bottom>
               <template #activator="{ props: subProps }">


### PR DESCRIPTION
resolves #69 
resolves #68
resolves #70 

- Updates the uploading and auto calculation of values to support more data formats.  Specifically the ide where the second item in the {girdId}_{name}_{date}_{time} has underscores in it.
- Fixes scrolling for longer shared recording lists in the main view
- Fixes a bug in creation of a scaled annotation (it now properly positions it)
- Adds duration to the lists of annotations for pulses and sequences
- Changes the type of sequences to a dropdown with the categorical labels that were decided on
- Adds a new option for visualizing time based on start/end points or duration and adds controls for that as well.  Defaults to that new duration time
- Updates the help labels for the new icons for time range endpoints vs the duration label.