### PR TITLE
fix name editing with missing time

### DIFF
--- a/client/src/components/BatchRecordingElement.vue
+++ b/client/src/components/BatchRecordingElement.vue
@@ -47,7 +47,7 @@ export default defineComponent({
         : new Date().toISOString().split("T")[0]
     ); // YYYY-MM-DD Time
     const recordedTime = ref(
-      props.editing ? props.editing.time.replaceAll(":", "") : getCurrentTime()
+      props.editing && props.editing.time ? props.editing.time.replace(/:/g, "") : getCurrentTime()
     ); // HHMMSS
     const uploadProgress = ref(0);
     const name = ref(props.editing ? props.editing.name : "");

--- a/client/src/components/UploadRecording.vue
+++ b/client/src/components/UploadRecording.vue
@@ -42,7 +42,7 @@ export default defineComponent({
     const errorText = ref('');
     const progressState = ref('');
     const recordedDate = ref(props.editing ? props.editing.date : new Date().toISOString().split('T')[0]); // YYYY-MM-DD Time
-    const recordedTime = ref(props.editing ? props.editing.time.replaceAll(':','') : getCurrentTime()); // HHMMSS
+    const recordedTime = ref(props.editing && props.editing.time ? props.editing.time.replace(/:/g, "") : getCurrentTime()); // HHMMSS
     const uploadProgress = ref(0);
     const name = ref(props.editing ? props.editing.name : '');
     const equipment = ref(props.editing ? props.editing.equipment : '');


### PR DESCRIPTION
resolves #88 

There was an issue when an upload didn't have a time associated with it.  It would cause an error when editing the name.  This should fix it and make the replacement of the name a bit more consistent.