### PR TITLE
renames acoustic batch to recording

### DIFF
--- a/bats_ai/api.py
+++ b/bats_ai/api.py
@@ -12,7 +12,7 @@ from bats_ai.core.views import (
     RecordingRouter,
     SpeciesRouter,
 )
-from bats_ai.core.views.nabat import AcouticBatchRouter
+from bats_ai.core.views.nabat import NABatRecordingRouter
 
 logger = logging.getLogger(__name__)
 
@@ -40,4 +40,4 @@ api.add_router('/guano/', GuanoMetadataRouter)
 api.add_router('/recording-annotation/', RecordingAnnotationRouter)
 api.add_router('/configuration/', ConfigurationRouter)
 api.add_router('/processing-task/', ProcessingTaskRouter)
-api.add_router('/nabat/acoustic-batch/', AcouticBatchRouter)
+api.add_router('/nabat/recording/', NABatRecordingRouter)

--- a/bats_ai/core/admin/__init__.py
+++ b/bats_ai/core/admin/__init__.py
@@ -3,9 +3,9 @@ from .compressed_spectrogram import CompressedSpectrogramAdmin
 from .grts_cells import GRTSCellsAdmin
 from .image import ImageAdmin
 from .nabat.admin import (
-    AcousticBatch,
-    AcousticBatchAnnotation,
     NABatCompressedSpectrogram,
+    NABatRecording,
+    NABatRecordingAnnotation,
     NABatSpectrogram,
 )
 from .processing_task import ProcessingTaskAdmin
@@ -26,9 +26,9 @@ __all__ = [
     'CompressedSpectrogramAdmin',
     'RecordingAnnotationAdmin',
     # NABat Models
-    'AcousticBatchAnnotation',
+    'NABatRecordingAnnotation',
     'NABatCompressedSpectrogram',
     'NABatSpectrogram',
-    'AcousticBatch',
+    'NABatRecording',
     'ProcessingTaskAdmin',
 ]

--- a/bats_ai/core/admin/nabat/admin.py
+++ b/bats_ai/core/admin/nabat/admin.py
@@ -1,26 +1,26 @@
 from django.contrib import admin
 
 from bats_ai.core.models.nabat import (
-    AcousticBatch,
-    AcousticBatchAnnotation,
     NABatCompressedSpectrogram,
+    NABatRecording,
+    NABatRecordingAnnotation,
     NABatSpectrogram,
 )
 
 
 # Register models for the NaBat category
-@admin.register(AcousticBatchAnnotation)
-class AcousticBatchAnnotationAdmin(admin.ModelAdmin):
+@admin.register(NABatRecordingAnnotation)
+class NABatRecordingAnnotationAdmin(admin.ModelAdmin):
     list_display = (
-        'acoustic_batch',
+        'nabat_recording',
         'comments',
         'model',
         'confidence',
         'additional_data',
         'species_codes',
     )
-    search_fields = ('acoustic_batch__name', 'comments', 'model')
-    list_filter = ('acoustic_batch',)
+    search_fields = ('nabat_recording_name', 'comments', 'model')
+    list_filter = ('nabat_recording',)
 
     @admin.display(description='Species Codes')
     def species_codes(self, obj):
@@ -31,7 +31,7 @@ class AcousticBatchAnnotationAdmin(admin.ModelAdmin):
 @admin.register(NABatSpectrogram)
 class NABatSpectrogramAdmin(admin.ModelAdmin):
     list_display = (
-        'acoustic_batch',
+        'nabat_recording',
         'image_file',
         'width',
         'height',
@@ -40,27 +40,27 @@ class NABatSpectrogramAdmin(admin.ModelAdmin):
         'frequency_max',
         'colormap',
     )
-    search_fields = ('acoustic_batch__name', 'colormap')
-    list_filter = ('acoustic_batch', 'colormap')
+    search_fields = ('nabat_recording__name', 'colormap')
+    list_filter = ('nabat_recording', 'colormap')
 
 
 @admin.register(NABatCompressedSpectrogram)
 class NABatCompressedSpectrogramAdmin(admin.ModelAdmin):
-    list_display = ('acoustic_batch', 'spectrogram', 'length', 'cache_invalidated')
-    search_fields = ('acoustic_batch__name', 'spectrogram__id')
-    list_filter = ('acoustic_batch', 'cache_invalidated')
+    list_display = ('nabat_recording', 'spectrogram', 'length', 'cache_invalidated')
+    search_fields = ('nabat_recording__name', 'spectrogram__id')
+    list_filter = ('nabat_recording', 'cache_invalidated')
 
 
-@admin.register(AcousticBatch)
-class AcousticBatchAdmin(admin.ModelAdmin):
+@admin.register(NABatRecording)
+class NABatRecordingAdmin(admin.ModelAdmin):
     list_display = (
         'name',
-        'batch_id',
+        'recording_id',
         'equipment',
         'comments',
         'recording_location',
         'grts_cell_id',
         'grts_cell',
     )
-    search_fields = ('name', 'batch_id', 'recording_location')
-    list_filter = ('name', 'batch_id', 'recording_location')
+    search_fields = ('name', 'recording_id', 'recording_location')
+    list_filter = ('name', 'recording_id', 'recording_location')

--- a/bats_ai/core/models/nabat/__init__.py
+++ b/bats_ai/core/models/nabat/__init__.py
@@ -1,11 +1,11 @@
-from .acoustic_batch import AcousticBatch
-from .acoustic_batch_annotation import AcousticBatchAnnotation
 from .nabat_compressed_spectrogram import NABatCompressedSpectrogram
+from .nabat_recording import NABatRecording
+from .nabat_recording_annotation import NABatRecordingAnnotation
 from .nabat_spectrogram import NABatSpectrogram
 
 __all__ = [
     'NABatSpectrogram',
     'NABatCompressedSpectrogram',
-    'AcousticBatch',
-    'AcousticBatchAnnotation',
+    'NABatRecording',
+    'NABatRecordingAnnotation',
 ]

--- a/bats_ai/core/models/nabat/nabat_compressed_spectrogram.py
+++ b/bats_ai/core/models/nabat/nabat_compressed_spectrogram.py
@@ -4,13 +4,13 @@ from django.db import models
 from django.dispatch import receiver
 from django_extensions.db.models import TimeStampedModel
 
-from .acoustic_batch import AcousticBatch
+from .nabat_recording import NABatRecording
 from .nabat_spectrogram import NABatSpectrogram
 
 
 # TimeStampedModel also provides "created" and "modified" fields
 class NABatCompressedSpectrogram(TimeStampedModel, models.Model):
-    acoustic_batch = models.ForeignKey(AcousticBatch, on_delete=models.CASCADE)
+    nabat_recording = models.ForeignKey(NABatRecording, on_delete=models.CASCADE)
     spectrogram = models.ForeignKey(NABatSpectrogram, on_delete=models.CASCADE)
     image_file = models.FileField()
     length = models.IntegerField()

--- a/bats_ai/core/models/nabat/nabat_recording.py
+++ b/bats_ai/core/models/nabat/nabat_recording.py
@@ -28,9 +28,9 @@ class colormap:
 
 
 # TimeStampedModel also provides "created" and "modified" fields
-class AcousticBatch(TimeStampedModel, models.Model):
+class NABatRecording(TimeStampedModel, models.Model):
     name = models.CharField(max_length=255)
-    batch_id = models.BigIntegerField(blank=False, null=False, unique=True)
+    recording_id = models.BigIntegerField(blank=False, null=False, unique=True)
     equipment = models.TextField(blank=True, null=True)
     comments = models.TextField(blank=True, null=True)
     recording_location = models.GeometryField(srid=4326, blank=True, null=True)
@@ -45,17 +45,17 @@ class AcousticBatch(TimeStampedModel, models.Model):
     nabat_manual_species = models.ForeignKey(Species, null=True, on_delete=models.SET_NULL)
     species_list = models.TextField(blank=True, null=True)
     nabat_auto_species = models.ForeignKey(
-        Species, null=True, on_delete=models.SET_NULL, related_name='acousticbatch_auto_species'
+        Species, null=True, on_delete=models.SET_NULL, related_name='nabatrecording_auto_species'
     )
     nabat_manual_species = models.ForeignKey(
-        Species, null=True, on_delete=models.SET_NULL, related_name='acousticbatch_manual_species'
+        Species, null=True, on_delete=models.SET_NULL, related_name='nabatrecording_manual_species'
     )
     computed_species = models.ManyToManyField(
-        Species, related_name='acousticbatch_computed_species'  # Changed related name
+        Species, related_name='nabatrecording_computed_species'  # Changed related name
     )  # species from a computed sense
 
     official_species = models.ManyToManyField(
-        Species, related_name='acousticbatch_official_species'  # Changed related name
+        Species, related_name='nabatrecording_official_species'  # Changed related name
     )  # species that are detemrined by the owner or from annotations as official species list
 
     unusual_occurrences = models.TextField(blank=True, null=True)
@@ -68,7 +68,7 @@ class AcousticBatch(TimeStampedModel, models.Model):
     def spectrograms(self):
         from bats_ai.core.models.nabat import NABatSpectrogram
 
-        query = NABatSpectrogram.objects.filter(acoustic_batch=self, colormap=COLORMAP).order_by(
+        query = NABatSpectrogram.objects.filter(nabat_recording=self, colormap=COLORMAP).order_by(
             '-created'
         )
         return query.all()
@@ -92,7 +92,7 @@ class AcousticBatch(TimeStampedModel, models.Model):
     def compressed_spectrograms(self):
         from bats_ai.core.models.nabat import NABatCompressedSpectrogram
 
-        query = NABatCompressedSpectrogram.objects.filter(acoustic_batch=self).order_by('-created')
+        query = NABatCompressedSpectrogram.objects.filter(nabat_recording=self).order_by('-created')
         return query.all()
 
     @property
@@ -107,5 +107,5 @@ class AcousticBatch(TimeStampedModel, models.Model):
         return spectrogram
 
     class Meta:
-        verbose_name = 'NABat Acoustic Batch'
-        verbose_name_plural = 'NABat Acoustic Batches'
+        verbose_name = 'NABat Recording'
+        verbose_name_plural = 'NABat Recording'

--- a/bats_ai/core/models/nabat/nabat_recording_annotation.py
+++ b/bats_ai/core/models/nabat/nabat_recording_annotation.py
@@ -4,11 +4,11 @@ from django_extensions.db.models import TimeStampedModel
 
 from bats_ai.core.models import Species
 
-from .acoustic_batch import AcousticBatch
+from .nabat_recording import NABatRecording
 
 
-class AcousticBatchAnnotation(TimeStampedModel, models.Model):
-    acoustic_batch = models.ForeignKey(AcousticBatch, on_delete=models.CASCADE)
+class NABatRecordingAnnotation(TimeStampedModel, models.Model):
+    nabat_recording = models.ForeignKey(NABatRecording, on_delete=models.CASCADE)
     species = models.ManyToManyField(Species)
     comments = models.TextField(blank=True, null=True)
     model = models.TextField(blank=True, null=True)  # AI Model information if inference used
@@ -25,5 +25,5 @@ class AcousticBatchAnnotation(TimeStampedModel, models.Model):
     )
 
     class Meta:
-        verbose_name = 'NABat Acoustic Batch Annotation'
-        verbose_name_plural = 'NABat Acoustic Batch Annotations'
+        verbose_name = 'NABat Recording Annotation'
+        verbose_name_plural = 'NABat Recording Annotations'

--- a/bats_ai/core/models/nabat/nabat_spectrogram.py
+++ b/bats_ai/core/models/nabat/nabat_spectrogram.py
@@ -8,14 +8,14 @@ from django.dispatch import receiver
 from django_extensions.db.models import TimeStampedModel
 import numpy as np
 
-from .acoustic_batch import AcousticBatch
+from .nabat_recording import NABatRecording
 
 logger = logging.getLogger(__name__)
 
 
 # TimeStampedModel also provides "created" and "modified" fields
 class NABatSpectrogram(TimeStampedModel, models.Model):
-    acoustic_batch = models.ForeignKey(AcousticBatch, on_delete=models.CASCADE)
+    nabat_recording = models.ForeignKey(NABatRecording, on_delete=models.CASCADE)
     image_file = models.FileField()
     width = models.IntegerField()  # pixels
     height = models.IntegerField()  # pixels

--- a/bats_ai/core/views/nabat/__init__.py
+++ b/bats_ai/core/views/nabat/__init__.py
@@ -1,5 +1,5 @@
-from .acoustic_batch import router as AcouticBatchRouter
+from .nabat_recording import router as NABatRecordingRouter
 
 __all__ = [
-    'AcouticBatchRouter',
+    'NABatRecordingRouter',
 ]

--- a/client/src/api/NABatApi.ts
+++ b/client/src/api/NABatApi.ts
@@ -1,49 +1,49 @@
 import { axiosInstance, FileAnnotation, ProcessingTask, Spectrogram } from "./api";
 
-export interface AcousticBatchCompleteResponse {
+export interface NABatRecordingCompleteResponse {
     error?: string;
     taskId: string;
     status?: ProcessingTask['status'];
 }
 
-export interface AcousticBatchDataResponse {
-    acousticId: string;
+export interface NABatRecordingDataResponse {
+    recordingId: string;
 }
-export type AcousticBatchResponse = AcousticBatchCompleteResponse | AcousticBatchDataResponse;
+export type NABatRecordingResponse = NABatRecordingCompleteResponse | NABatRecordingDataResponse;
 
-function isAcousticBatchCompleteResponse(response: AcousticBatchResponse): response is AcousticBatchCompleteResponse {
+function isNABatRecordingCompleteResponse(response: NABatRecordingResponse): response is NABatRecordingCompleteResponse {
     return "taskId" in response;
 }
 
-async function postAcousticBatch(batchId: number, apiToken: string) {
+async function postNABatRecording(recordingId: number, apiToken: string) {
     const formData = new FormData();
-    formData.append('batchId', batchId.toString());
+    formData.append('recordingId', recordingId.toString());
     formData.append('apiToken', apiToken);
-    const response =  (await (axiosInstance.post<AcousticBatchResponse>('/nabat/acoustic-batch/', formData))).data;
-    if (isAcousticBatchCompleteResponse(response)) {
-        return response as AcousticBatchCompleteResponse;
+    const response =  (await (axiosInstance.post<NABatRecordingResponse>('/nabat/recording/', formData))).data;
+    if (isNABatRecordingCompleteResponse(response)) {
+        return response as NABatRecordingCompleteResponse;
     }
-    return response as AcousticBatchDataResponse;
+    return response as NABatRecordingDataResponse;
 }
 
 async function getSpectrogram(id: string) {
-    return axiosInstance.get<Spectrogram>(`/nabat/acoustic-batch/${id}/spectrogram`);
+    return axiosInstance.get<Spectrogram>(`/nabat/recording/${id}/spectrogram`);
 }
 
 async function getSpectrogramCompressed(id: string) {
-    return axiosInstance.get<Spectrogram>(`/nabat/acoustic-batch/${id}/spectrogram/compressed`);
+    return axiosInstance.get<Spectrogram>(`/nabat/recording/${id}/spectrogram/compressed`);
 
 }
 
-async function getAcousticFileAnnotations(batchId: number) {
-    return axiosInstance.get<FileAnnotation[]>(`/nabat/acoustic-batch/${batchId}/recording-annotations`);
+async function getNABatRecordingFileAnnotations(recordingId: number) {
+    return axiosInstance.get<FileAnnotation[]>(`/nabat/recording/${recordingId}/recording-annotations`);
 }
 
 
 
 export {
-    postAcousticBatch,
+    postNABatRecording,
     getSpectrogram,
     getSpectrogramCompressed,
-    getAcousticFileAnnotations,
+    getNABatRecordingFileAnnotations,
 };

--- a/client/src/api/api.ts
+++ b/client/src/api/api.ts
@@ -36,7 +36,7 @@ export interface Recording {
     unusual_occurrences?: string;
 }
 
-export interface AcousticFiles {
+export interface NATBatFiles {
     id: number,
     recording_time: string;
     recording_location: string | null;
@@ -382,7 +382,7 @@ export interface ProcessingTask {
     error? : string;
     info?: string;
     status: 'Complete' | 'Running' | 'Error' | 'Queued';
-    metadata: Record<string, unknown> & { type?: 'AcousticBatchProcessing' } & { batchId: string };
+    metadata: Record<string, unknown> & { type?: 'NABatRecordingProcessing' } & { recordingId: string };
     output_metadata: Record<string, unknown>;
 }
 export interface ProcessingTaskDetails {

--- a/client/src/components/RecordingAnnotations.vue
+++ b/client/src/components/RecordingAnnotations.vue
@@ -3,7 +3,7 @@ import { defineComponent, onMounted, PropType, Ref } from "vue";
 import { ref } from "vue";
 import { FileAnnotation, getFileAnnotations, putFileAnnotation, Species, UpdateFileAnnotation } from "../api/api";
 import RecordingAnnotationEditor from "./RecordingAnnotationEditor.vue";
-import { getAcousticFileAnnotations } from "../api/NABatApi";
+import { getNABatRecordingFileAnnotations } from "../api/NABatApi";
 export default defineComponent({
   name: "AnnotationList",
   components: {
@@ -37,7 +37,7 @@ export default defineComponent({
 
     const loadFileAnnotations = async () => {
       if (props.type === 'nabat') {
-        annotations.value = (await getAcousticFileAnnotations(props.recordingId)).data;
+        annotations.value = (await getNABatRecordingFileAnnotations(props.recordingId)).data;
       } else {
         annotations.value = (await getFileAnnotations(props.recordingId)).data;
       }

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -6,7 +6,7 @@ import Login from '../views/Login.vue';
 
 import oauthClient from '../plugins/Oauth';
 import Admin from '../views/Admin.vue';
-import NABatAcousticBatch from '../views/NABatAcousticBatch.vue';
+import NABatRecording from '../views/NABatRecording.vue';
 import NABatSpectrogram from '../views/NABatSpectrogram.vue';
 
 function beforeEach(
@@ -57,10 +57,10 @@ function routerInit(){
       },
 
       {
-        path: '/nabat/:batchId/',
-        component: NABatAcousticBatch,
+        path: '/nabat/:recordingId/',
+        component: NABatRecording,
         props: (route) => ({
-          batchId: parseInt(route.params.batchId as string, 10),
+          recordingId: parseInt(route.params.recordingId as string, 10),
           apiToken: route.query.apiToken,
         }),
       },

--- a/client/src/views/NABatAcousticBatch.vue
+++ b/client/src/views/NABatAcousticBatch.vue
@@ -2,12 +2,12 @@
   <script lang="ts">
   import { defineComponent, ref, onMounted, onUnmounted, Ref} from 'vue';
 import { getProcessingTaskDetails } from '../api/api';
-import { AcousticBatchDataResponse, postAcousticBatch } from '../api/NABatApi';
+import { NABatRecordingDataResponse, postNABatRecording } from '../api/NABatApi';
 import { useRouter } from 'vue-router';
   
   export default defineComponent({
     props: {
-      batchId: {
+      recordingId: {
         type: Number,
         required: true,
       },
@@ -35,7 +35,7 @@ import { useRouter } from 'vue-router';
                 timeoutId = null;
               }
               taskInfo.value = '';
-              await checkAcousticBatch();
+              await checkNABatRecording();
               return;
             } else if (response.celery_data.status === 'Error') {
               loading.value = false;
@@ -53,9 +53,9 @@ import { useRouter } from 'vue-router';
         timeoutId = setTimeout(fetchTaskDetails, 1000);
       };
 
-      const checkAcousticBatch = async () => {
+      const checkNABatRecording = async () => {
         try {
-          const response = await postAcousticBatch(props.batchId, props.apiToken);
+          const response = await postNABatRecording(props.recordingId, props.apiToken);
           if ('error' in response && response.error) {
             loading.value = false;
             errorMessage.value = response.error;
@@ -65,7 +65,7 @@ import { useRouter } from 'vue-router';
           } else {
             loading.value = false;
             // Load in new NABatSpectrogramViewer either by route or component
-            const id = (response as AcousticBatchDataResponse).acousticId;
+            const id = (response as NABatRecordingDataResponse).recordingId;
             router.push(`/nabat/${id}/spectrogram`);
           }
         } catch (error) {
@@ -74,7 +74,7 @@ import { useRouter } from 'vue-router';
         }
       };
   
-      onMounted(async () => checkAcousticBatch());
+      onMounted(async () => checkNABatRecording());
   
       onUnmounted(() => {
         if (timeoutId !== null) {


### PR DESCRIPTION
PR to rename everything that was acoustic batch to recording for eventual integration where the logic of NABat integration operates on a recording and not an acoustic batch.

I didn't want to keep all the acoustic_batch references if we are operating on an internal 'recording' named structure from NABat.