### PR TITLE
Don't use computed ref for compressed state

### DIFF
--- a/client/src/views/Spectrogram.vue
+++ b/client/src/views/Spectrogram.vue
@@ -65,7 +65,7 @@ export default defineComponent({
     const loadedImage = ref(false);
     const gridEnabled = ref(false);
     const recordingInfo = ref(false);
-    const compressed = computed(() => configuration.value.spectrogram_view === 'compressed');
+    const compressed =  ref(configuration.value.spectrogram_view === 'compressed');
     const getAnnotationsList = async (annotationId?: number) => {
       const response = await getAnnotations(props.id);
       annotations.value = response.data.sort(


### PR DESCRIPTION
There was a bug introduced where the `compressed` state of the spectrogram viewer is initialized as a computed prop. This prevents being able to set it by clicked the "Toggle Compressed View" button in the UI. This changes that to use a normal ref whose initial value is that of the config.