### PR TITLE
adding minio to prod build of container

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ setup(
             'django-composed-configuration[prod]>=0.20',
             'django-s3-file-field[boto3, minio]',
             'django-minio-storage>=0.5.2',
+            'gunicorn',
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
         ],
         'prod': [
             'django-composed-configuration[prod]>=0.20',
-            'django-s3-file-field[boto3]',
+            'django-s3-file-field[boto3, minio]',
             'django-minio-storage>=0.5.2',
         ],
     },


### PR DESCRIPTION
Adds in the minio version of the django-s3-file-field for our deployment image.  This is because our current on-prem deployed version is using minIO.

The future may have a requirement where we have a boto3/S3 version for AWS S3/EC2 deployment.