### PR TITLE
Switch to grayscale spectrograms by default

### DIFF
--- a/bats_ai/tasks/nabat/tasks.py
+++ b/bats_ai/tasks/nabat/tasks.py
@@ -106,7 +106,7 @@ def generate_spectrogram(nabat_recording, file, colormap=None, dpi=520):
         }
 
         if colormap is None:
-            librosa.display.specshow(chunk, **kwargs)
+            librosa.display.specshow(chunk, cmap='gray', **kwargs)
         else:
             librosa.display.specshow(chunk, cmap=colormap, **kwargs)
 

--- a/bats_ai/tasks/tasks.py
+++ b/bats_ai/tasks/tasks.py
@@ -108,7 +108,7 @@ def generate_spectrogram(recording, file, colormap=None, dpi=520):
         }
 
         if colormap is None:
-            librosa.display.specshow(chunk, **kwargs)
+            librosa.display.specshow(chunk, cmap='gray', **kwargs)
         else:
             librosa.display.specshow(chunk, cmap=colormap, **kwargs)
 


### PR DESCRIPTION
Fix #170 

This seemed to be the least intrusive way to make this change. Instead of using the default colormap when calling `librosa.specshow`, we pass the argument `cmap='gray'` to get a grayscale image, which works much more nicely with the SVG filtering done on the frontend for applying custom color schemes.