### PR TITLE
Use explicit user fixtures

### DIFF
--- a/bats_ai/core/tests/conftest.py
+++ b/bats_ai/core/tests/conftest.py
@@ -1,7 +1,6 @@
 from django.contrib.auth.models import User
 from django.test import Client
 import pytest
-from pytest_factoryboy import register
 
 from .factories import SuperuserFactory, UserFactory
 
@@ -9,6 +8,16 @@ from .factories import SuperuserFactory, UserFactory
 @pytest.fixture
 def client() -> Client:
     return Client()
+
+
+@pytest.fixture
+def user() -> User:
+    return UserFactory()
+
+
+@pytest.fixture
+def superuser() -> User:
+    return SuperuserFactory()
 
 
 @pytest.fixture
@@ -23,7 +32,3 @@ def authorized_client(superuser: User) -> Client:
     client = Client()
     client.force_login(user=superuser)
     return client
-
-
-register(UserFactory, 'user')
-register(SuperuserFactory, 'superuser')


### PR DESCRIPTION
Pytest 8.4 released yesterday. I believe there is an [incompatibility](https://github.com/pytest-dev/pytest-factoryboy/pull/233) with `pytest-factoryboy` at the moment.

We could either:

1. Pin pytest to version 8.3 until the incompatibility is resolved, or
2. Stop using `pytest-factoryboy` features that don't work right now

This PR applies option 2 to our tests.