### PR TITLE
remove auth for task-details

### DIFF
--- a/bats_ai/core/views/processing_tasks.py
+++ b/bats_ai/core/views/processing_tasks.py
@@ -12,7 +12,8 @@ logger = logging.getLogger(__name__)
 router = Router()
 
 
-@router.get('/{task_id}/details')
+# Auth is None
+@router.get('/{task_id}/details', auth=None)
 def task_details(request, task_id: str):
     task = get_object_or_404(ProcessingTask, celery_id=task_id)
     celery_task = AsyncResult(task.celery_id)


### PR DESCRIPTION
resolves #183 

This endpoint is called during NABat's creation of a spectrogram. It's used to determine the current status of the creation of the spectrogram.  Standard users won't be logged in so they won't have access to this endpoint.

I could use some of this code: https://github.com/Kitware/batai/blob/main/bats_ai/core/views/nabat/nabat_recording.py#L83
and have an optional JWT token that would only check for an email address.  It's easier to I think just make the auth none.  The only infomration returned is the current status of the processing task.