### PR TITLE
Dynamic Subpath Support for Deployment

### DIFF
--- a/bats_ai/settings.py
+++ b/bats_ai/settings.py
@@ -70,6 +70,7 @@ class BatsAiMixin(ConfigMixin):
 
 class DevelopmentConfiguration(BatsAiMixin, DevelopmentBaseConfiguration):
     SECRET_KEY = 'secretkey'  # Dummy value for local development configuration
+
     baseHost = 'localhost'
     if 'SERVERHOSTNAME' in os.environ:
         baseHost = os.environ['SERVERHOSTNAME']
@@ -96,6 +97,12 @@ class TestingConfiguration(BatsAiMixin, TestingBaseConfiguration):
 
 
 class KitwareConfiguration(BatsAiMixin, _BaseConfiguration):
+    subpath = os.environ.get('SUBPATH', '').strip('/')
+
+    # If SUBPATH is non-empty, prefix URLs accordingly, else use defaults
+    STATIC_URL = f'/{subpath}/static/' if subpath else '/static/'
+    LOGIN_URL = f'/{subpath}/accounts/login/' if subpath else '/accounts/login/'
+    USE_X_FORWARDED_HOST = True  # If behind a proxy
     SECRET_KEY = values.SecretValue()
     baseHost = 'batdetectai.kitware.com'
     if 'SERVERHOSTNAME' in os.environ:
@@ -115,7 +122,7 @@ class KitwareConfiguration(BatsAiMixin, _BaseConfiguration):
     MINIO_STORAGE_AUTO_CREATE_MEDIA_BUCKET = True
     MINIO_STORAGE_AUTO_CREATE_MEDIA_POLICY = 'READ_WRITE'
     MINIO_STORAGE_MEDIA_USE_PRESIGNED = True
-    MINIO_STORAGE_MEDIA_URL = f'http://{baseHost}:9000/django-storage'
+    MINIO_STORAGE_MEDIA_URL = f'https://{baseHost}:9000/django-storage'
     ALLOWED_HOSTS = [baseHost]
     CSRF_TRUSTED_ORIGINS = [f'https://{baseHost}', f'https://{baseHost}']
     CORS_ORIGIN_WHITELIST = [f'https://{baseHost}', f'https://{baseHost}']
@@ -130,6 +137,12 @@ class HerokuProductionConfiguration(BatsAiMixin, HerokuProductionBaseConfigurati
 
 
 class AwsProductionConfiguration(BatsAiMixin, _BaseConfiguration):
+    SUBPATH = os.environ.get('SUBPATH', '').strip('/')
+
+    # If SUBPATH is non-empty, prefix URLs accordingly, else use defaults
+    STATIC_URL = f'/{SUBPATH}/static/' if SUBPATH else '/static/'
+    LOGIN_URL = f'/{SUBPATH}/accounts/login/' if SUBPATH else '/accounts/login/'
+
     DEFAULT_FILE_STORAGE = 'storages.backends.s3.S3Storage'
     baseHost = '[batdetectai.kitware.com](http://batdetectai.kitware.com/)'
     if 'SERVERHOSTNAME' in os.environ:

--- a/bats_ai/settings.py
+++ b/bats_ai/settings.py
@@ -122,7 +122,7 @@ class KitwareConfiguration(BatsAiMixin, _BaseConfiguration):
     MINIO_STORAGE_AUTO_CREATE_MEDIA_BUCKET = True
     MINIO_STORAGE_AUTO_CREATE_MEDIA_POLICY = 'READ_WRITE'
     MINIO_STORAGE_MEDIA_USE_PRESIGNED = True
-    MINIO_STORAGE_MEDIA_URL = f'https://{baseHost}:9000/django-storage'
+    MINIO_STORAGE_MEDIA_URL = f'https://{baseHost}/django-storage'
     ALLOWED_HOSTS = [baseHost]
     CSRF_TRUSTED_ORIGINS = [f'https://{baseHost}', f'https://{baseHost}']
     CORS_ORIGIN_WHITELIST = [f'https://{baseHost}', f'https://{baseHost}']

--- a/bats_ai/urls.py
+++ b/bats_ai/urls.py
@@ -1,3 +1,5 @@
+import os
+
 from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
@@ -6,10 +8,8 @@ from drf_yasg.views import get_schema_view
 from rest_framework import permissions
 
 from bats_ai.core.rest import rest
-
 from .api import api
 
-# Some more specific Api Requests
 # OpenAPI generation
 schema_view = get_schema_view(
     openapi.Info(title='bats-ai', default_version='v1', description=''),
@@ -17,7 +17,8 @@ schema_view = get_schema_view(
     permission_classes=(permissions.AllowAny,),
 )
 
-urlpatterns = [
+# Core URL patterns
+base_urlpatterns = [
     path('accounts/', include('allauth.urls')),
     path('oauth/', include('oauth2_provider.urls')),
     path('admin/', admin.site.urls),
@@ -29,6 +30,14 @@ urlpatterns = [
     path('', include('django_large_image.urls')),
 ]
 
+# Add subpath prefix if SUBPATH is defined
+subpath = os.environ.get("SUBPATH", "").strip("/")
+if subpath:
+    urlpatterns = [path(f"{subpath}/", include(base_urlpatterns))]
+else:
+    urlpatterns = base_urlpatterns
+
+# Add debug toolbar if in DEBUG mode
 if settings.DEBUG:
     import debug_toolbar
 

--- a/bats_ai/urls.py
+++ b/bats_ai/urls.py
@@ -8,6 +8,7 @@ from drf_yasg.views import get_schema_view
 from rest_framework import permissions
 
 from bats_ai.core.rest import rest
+
 from .api import api
 
 # OpenAPI generation
@@ -31,9 +32,9 @@ base_urlpatterns = [
 ]
 
 # Add subpath prefix if SUBPATH is defined
-subpath = os.environ.get("SUBPATH", "").strip("/")
+subpath = os.environ.get('SUBPATH', '').strip('/')
 if subpath:
-    urlpatterns = [path(f"{subpath}/", include(base_urlpatterns))]
+    urlpatterns = [path(f'{subpath}/', include(base_urlpatterns))]
 else:
     urlpatterns = base_urlpatterns
 

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -26,11 +26,14 @@ function beforeEach(
   }
   next();
 }
+const subpath = import.meta.env.VITE_APP_SUBPATH?.replace(/\/+$/, '');
+const routerBase = subpath ? `/${subpath}/` : '/';
 
 
 function routerInit(){
   const router  = createRouter({
-    history: createWebHistory(),
+    base: routerBase,
+    history: createWebHistory(routerBase),
     routes: [
       {
         path: '/',

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -2,9 +2,11 @@ import path from 'path';
 import { defineConfig } from 'vite';
 import Vue from '@vitejs/plugin-vue';
 import Vuetify from 'vite-plugin-vuetify';
+const subpath = process.env.VITE_APP_SUBPATH || './';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: subpath.endsWith('/') ? subpath : `${subpath}/`,
   envPrefix: 'VITE_APP_',
   define: {
     // Populated by netlify https://docs.netlify.com/configure-builds/environment-variables/

--- a/dev/.env.prod.docker-compose.template
+++ b/dev/.env.prod.docker-compose.template
@@ -20,3 +20,4 @@ VITE_APP_API_ROOT=https://batdetectai.kitware.com/api/v1
 VITE_APP_OAUTH_API_ROOT=https://batdetectai.kitware.com/oauth/
 VITE_APP_OAUTH_CLIENT_ID=HSJWFZ2cIpWQOvNyCXyStV9hiOd7DfWeBOCzo4pP
 VITE_APP_LOGIN_REDIRECT=https://batdetectai.kitware.com
+SUBPATH=

--- a/dev/client.Dockerfile
+++ b/dev/client.Dockerfile
@@ -33,6 +33,7 @@ ENV VITE_APP_OAUTH_API_ROOT=${VITE_APP_OAUTH_API_ROOT}
 ENV VITE_APP_OAUTH_CLIENT_ID=${VITE_APP_OAUTH_CLIENT_ID}
 ENV VITE_APP_LOGIN_REDIRECT=${VITE_APP_LOGIN_REDIRECT}
 ENV SUBPATH=${SUBPATH}
+ENV VITE_APP_SUBPATH=${SUBPATH}
 
 # Run Vue build
 RUN npm run build
@@ -57,12 +58,12 @@ COPY nginx/nginx.subpath.template /nginx.subpath.template
 COPY nginx/nginx.conf /nginx.conf
 
 RUN if [ -n "$SUBPATH" ]; then \
-        echo "📦 Copying Vue build to /usr/share/nginx/html/${SUBPATH}"; \
+        echo "Copying Vue build to /usr/share/nginx/html/${SUBPATH}"; \
         mkdir -p /usr/share/nginx/html/${SUBPATH}; \
         cp -r /tmp/dist/* /usr/share/nginx/html/${SUBPATH}/; \
         envsubst '${SUBPATH}' < /nginx.subpath.template > /etc/nginx/nginx.conf; \
     else \
-        echo "📦 No SUBPATH set. Using default nginx.conf"; \
+        echo "No SUBPATH set. Using default nginx.conf"; \
         cp /nginx.conf /etc/nginx/nginx.conf; \
         cp -r /tmp/dist/* /usr/share/nginx/html/; \
     fi

--- a/dev/client.Dockerfile
+++ b/dev/client.Dockerfile
@@ -57,6 +57,7 @@ COPY --from=build-stage /app/dist /tmp/dist
 COPY nginx/nginx.subpath.template /nginx.subpath.template
 COPY nginx/nginx.conf /nginx.conf
 
+# hadolint ignore=SC2016
 RUN if [ -n "$SUBPATH" ]; then \
         echo "Copying Vue build to /usr/share/nginx/html/${SUBPATH}"; \
         mkdir -p /usr/share/nginx/html/${SUBPATH}; \

--- a/dev/django.Dockerfile
+++ b/dev/django.Dockerfile
@@ -39,7 +39,7 @@ ARG BUILD_ENV
 
 # If not bind mounted we need bats_ai for celery deployment
 # The bind mount will override this directory
-COPY ./bats_ai /opt/django-project/
+COPY ./ /opt/django-project/
 
 # hadolint ignore=DL3013
 RUN set -ex \

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -51,7 +51,7 @@ services:
     # command: ""
     # Log printing via Rich is enhanced by a TTY
     tty: true
-    env_file: 
+    env_file:
       - ./dev/.env.prod.docker-compose
     networks:
       - django-nginx

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -81,7 +81,7 @@ services:
     ]
     # Docker Compose does not set the TTY width, which causes Celery errors
     tty: false
-    env_file: 
+    env_file:
       - ./dev/.env.prod.docker-compose
     networks:
       - django-nginx
@@ -102,7 +102,7 @@ services:
         VITE_APP_OAUTH_CLIENT_ID: ${VITE_APP_OAUTH_CLIENT_ID}
         VITE_APP_LOGIN_REDIRECT: ${VITE_APP_LOGIN_REDIRECT}
         SUBPATH: ${SUBPATH}
-    env_file: 
+    env_file:
      - ./dev/.env.prod.docker-compose
     networks:
       - django-nginx
@@ -127,7 +127,7 @@ services:
       - postgres:/var/lib/postgresql/data
 
   rabbitmq:
-    env_file: 
+    env_file:
       - ./dev/.env.prod.docker-compose
     image: rabbitmq:management
     networks:
@@ -143,7 +143,7 @@ services:
     # When run with a TTY, minio prints credentials on startup
     tty: true
     command: ["server", "/data", "--console-address", ":${DOCKER_MINIO_CONSOLE_PORT-9001}"]
-    env_file: 
+    env_file:
       - ./dev/.env.prod.docker-compose
     environment:
       - MINIO_ROOT_USER=${DJANGO_MINIO_STORAGE_ACCESS_KEY:-minioAccessKey}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -51,7 +51,8 @@ services:
     # command: ""
     # Log printing via Rich is enhanced by a TTY
     tty: true
-    env_file: ./dev/.env.prod.docker-compose
+    env_file: 
+      - ./dev/.env.prod.docker-compose
     networks:
       - django-nginx
     volumes:
@@ -80,7 +81,8 @@ services:
     ]
     # Docker Compose does not set the TTY width, which causes Celery errors
     tty: false
-    env_file: ./dev/.env.prod.docker-compose
+    env_file: 
+      - ./dev/.env.prod.docker-compose
     networks:
       - django-nginx
     depends_on:
@@ -94,7 +96,14 @@ services:
     build:
       context: .
       dockerfile: ./dev/client.Dockerfile
-    env_file: ./dev/.env.prod.docker-compose
+      args:
+        VITE_APP_API_ROOT: ${VITE_APP_API_ROOT}
+        VITE_APP_OAUTH_API_ROOT: ${VITE_APP_OAUTH_API_ROOT}
+        VITE_APP_OAUTH_CLIENT_ID: ${VITE_APP_OAUTH_CLIENT_ID}
+        VITE_APP_LOGIN_REDIRECT: ${VITE_APP_LOGIN_REDIRECT}
+        SUBPATH: ${SUBPATH}
+    env_file: 
+     - ./dev/.env.prod.docker-compose
     networks:
       - django-nginx
     depends_on:
@@ -118,7 +127,8 @@ services:
       - postgres:/var/lib/postgresql/data
 
   rabbitmq:
-    env_file: ./dev/.env.prod.docker-compose
+    env_file: 
+      - ./dev/.env.prod.docker-compose
     image: rabbitmq:management
     networks:
       - django-nginx
@@ -133,7 +143,8 @@ services:
     # When run with a TTY, minio prints credentials on startup
     tty: true
     command: ["server", "/data", "--console-address", ":${DOCKER_MINIO_CONSOLE_PORT-9001}"]
-    env_file: ./dev/.env.prod.docker-compose
+    env_file: 
+      - ./dev/.env.prod.docker-compose
     environment:
       - MINIO_ROOT_USER=${DJANGO_MINIO_STORAGE_ACCESS_KEY:-minioAccessKey}
       - MINIO_ROOT_PASSWORD=${DJANGO_MINIO_STORAGE_SECRET_KEY:-minioSecretKey}

--- a/nginx/nginx.subpath.template
+++ b/nginx/nginx.subpath.template
@@ -1,0 +1,81 @@
+worker_processes  1;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    client_max_body_size 100m;
+
+    server {
+        listen 80;
+
+        # Serve Vue.js static files
+
+        location /${SUBPATH} {
+            root /usr/share/nginx/html;
+            index index.html;
+            try_files $uri $uri/ /${SUBPATH}/index.html;
+        }
+
+        location /${SUBPATH}/api {
+            proxy_pass http://django:8000/${SUBPATH}/api;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_redirect off;
+        }
+
+        location /${SUBPATH}/oauth {
+            proxy_pass http://django:8000/${SUBPATH}/oauth;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_redirect off;
+        }
+
+        location /${SUBPATH}/static {
+            proxy_pass http://django:8000/${SUBPATH}/static;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_redirect off;
+        }
+
+        location /${SUBPATH}/admin {
+            proxy_pass http://django:8000/${SUBPATH}/admin;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-SCRIPT-NAME /${SUBPATH}/;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_redirect off;
+        }
+
+
+
+        location /${SUBPATH}/accounts {
+            proxy_pass http://django:8000/${SUBPATH}/accounts;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_redirect off;
+        }
+
+        location /django-storage {
+            proxy_pass http://minio:9000/django-storage;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_redirect off;
+        }
+
+    }
+}


### PR DESCRIPTION
This update should allow for dynamic subpath values that can be used for deploying the application.

Deployment Notes:

- `SUBPATH` - New Environment Variable that needs to be added to the .env.prod.docker-compose or other deployment sections.  If this is empty (`SUBPATH=`) it will fall back to old behavior.  If it has a subpath it will be added to the client and django for all applications to provide a new `example.com/subpath` for all values
- **IMPORTANT** - the client build process has been updated so if you update your `./dev/.env.prod.docker-compose` you need to run the following command before building:
    - `source ./dev/export-env.sh ./dev/.env.prod.docker-compose`
    - This command prevents needing to copy the .env file into the ./client folder, the build process will do it instead
    - use `docker compose -f docker-compose.prod.yml config` to confirm that the client: build arguments have the SUBPATH set


Dev/Review Notes:

- .env.prod.docker-compose.template has a new value `SUBPATH` if empty it will use default deployment.  If it has a value it updates the client build and the django runtime environment variables to support having a subpath
- Django Updates
    - `settings.py` now has two new settings that are changed based on the SUBPATH environment varaible
        - `STATIC_URL` - dynamically set to make sure that static assests in swagger/login are updated to the newer subpath
        - `LOGIN_URL` - the login page goeas to `/oauth` which redirects to `/accounts/login` this makes it so it redirects to `{SUBPATH}/accounts/login` instead
    - `urls.py` - This is updated to prefix a path to all the endpoints that are used based on the SUBPATH environment variable
        - Just takes all of the URLPatterns we are already using and changes the path to make them have a different path
- Client Updates
    - The client dockerfile will now handle building and passing in `SUBPATH` as `VITE_APP_SUBPATH` before building so the vite knows what the subpath is.
    - `vite-config.js` - Updates the base for vite config.  This makes it so all assets reference `/{Base}/asset` instead of direction referencing the asset so the system can handle a subpath
    - `router/index.ts` the routes need to have the same base value so they append thme to the beginning and sharing the url leads to the proper location.
- nginx Updates
    - Created a new file `nginx.subpath.template` that has templated values for `subpath` in it that can be replaced using a shell script.  This file is only used if the subpath is a non-empty value
- Docker Build Updates
    - Client/NGINX updates
        - Passes in the VITE_APP variables as build arguments as well as SUBPATH.
        - **NOTE** These arguments are not found in the runtime .env file for the client so they need to be `sourced` using the `./dev/export.env.sh` script before building.  That is how these values are properly passed into the system
        - These values are then output into the /client directory as a `.env.production` file
        - The build /dist file is placed in a tmp location and the nginx.conf and the nginx.subpath.conf are placed in the root location
        - A conditional checks to see if the SUBPATH is empty or not
           - If empty the nginx.conf is copied to /etc/nginx/nginx.conf and the dist directory is placed in /usr/share/nginx/html to be served.
           - If it is not empty a shell script takes the nginx.subpath.conf file and replaces all instances of `${SUBPATH}` with the value and uses that as the /etc/nginx/nginx.conf.  Then the dist directory is copied to /usr/share/nginx/html/{SUBPATH}/ to be served.

