### PR TITLE
fix base vite bath without subpath

### DIFF
--- a/bats_ai/core/views/nabat/nabat_configuration.py
+++ b/bats_ai/core/views/nabat/nabat_configuration.py
@@ -6,8 +6,8 @@ import uuid
 
 from django.contrib.gis.db.models import functions as gis_functions
 from django.contrib.gis.geos import Point, Polygon
-from django.db.models import Count
 from django.db import transaction
+from django.db.models import Count
 from django.http import HttpRequest, JsonResponse
 from django.utils.timezone import now
 from ninja import Query, Router, Schema

--- a/bats_ai/core/views/nabat/nabat_recording.py
+++ b/bats_ai/core/views/nabat/nabat_recording.py
@@ -3,8 +3,8 @@ import json
 import logging
 import os
 
-from django.db.models import Q
 from django.db import transaction
+from django.db.models import Q
 from django.http import HttpRequest, JsonResponse
 from ninja import Form, Schema
 from ninja.pagination import RouterPaginated

--- a/bats_ai/tasks/nabat/nabat_data_retrieval.py
+++ b/bats_ai/tasks/nabat/nabat_data_retrieval.py
@@ -5,8 +5,8 @@ import tempfile
 
 from django.contrib.gis.geos import Point
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
-from django.db.models import Q
 from django.db import transaction
+from django.db.models import Q
 import requests
 
 from bats_ai.celery import app

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -2,7 +2,7 @@ import path from 'path';
 import { defineConfig } from 'vite';
 import Vue from '@vitejs/plugin-vue';
 import Vuetify from 'vite-plugin-vuetify';
-const subpath = process.env.VITE_APP_SUBPATH || './';
+const subpath = process.env.VITE_APP_SUBPATH || '/';
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
- The default vite path without a subpath should be `/` and not `./`.  Updated this to fix the issue of running the system without 
- some minor transaction updates for creation of celerytasks to prevent other works from conflicting.