### PR TITLE
NABat Error Logging

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -54,7 +54,7 @@ to `.env` and change the default passwords for fields
    and change the ApplicationId to the ID in the `./client.env.production`
 9. Test logging in/out and uploading data to the server.
 
-### GRTS Cell Id suppoer
+### GRTS Cell Id support
 
 Make sure that there is the grts.csv in the /opt/batai/dev/grtsCells folder
 

--- a/bats_ai/tasks/nabat/tasks.py
+++ b/bats_ai/tasks/nabat/tasks.py
@@ -1,4 +1,5 @@
 import io
+import logging
 import math
 import tempfile
 
@@ -25,6 +26,8 @@ FREQ_MAX = 120e3
 FREQ_PAD = 2e3
 
 COLORMAP_ALLOWED = [None, 'gist_yarg', 'turbo']
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger('NABatDataRetrieval')
 
 
 def generate_spectrogram(nabat_recording, file, colormap=None, dpi=520):
@@ -32,8 +35,8 @@ def generate_spectrogram(nabat_recording, file, colormap=None, dpi=520):
         sig, sr = librosa.load(file, sr=None)
         duration = len(sig) / sr
     except Exception as e:
-        print(f'Error loading file: {e}')
-        return None
+        logging.error(f'Error loading file: {e}')
+        raise Exception(f'Error loading file: {e}')
 
     size_mod = 1
     high_res = False
@@ -51,7 +54,7 @@ def generate_spectrogram(nabat_recording, file, colormap=None, dpi=520):
         high_res = True
 
     if colormap not in COLORMAP_ALLOWED:
-        print(f'Substituted requested {colormap} colormap to default')
+        logger.info(f'Substituted requested {colormap} colormap to default')
         colormap = None
 
     size = int(0.001 * sr)  # 1.0ms resolution


### PR DESCRIPTION
- Improves NABat Error Logging by ensuring errors are raised properly.
- Adds some additional errors for failing to download the presigned URL
- Loading of malformed WAV files should properly error and raise as well
- There was a bug with the indentation of processing and adding existing Annotations from NABat
    - Specifically, it was trying to access `batch_data` in the for loop without it being set to a value properly.  I.E, the length of `acoustic_batches_nodes` was zero, and it was still trying to iterate over an empty and non-referenced data.  Indenting this under the conditional should resolve the issue.