### PR TITLE
Thumbnail scaling

### DIFF
--- a/client/src/components/ColorPickerMenu.vue
+++ b/client/src/components/ColorPickerMenu.vue
@@ -10,6 +10,10 @@ defineProps({
 const colorpickerMenu = ref(false);
 const color = defineModel({ default: 'rgb(0, 0, 0)'});
 function updateColor(colorVal: string) {
+  if (!colorVal.includes(',')) {
+    // convert rgb(0 0 0) to rgb(0, 0, 0)
+    colorVal = colorVal.replace(/rgb\((\d+)\s+(\d+)\s+(\d+)\)/, 'rgb($1, $2, $3)');
+  }
   const d3Color = d3.color(colorVal);
   if (d3Color) {
     color.value = d3Color.formatRgb();

--- a/client/src/components/SpectrogramViewer.vue
+++ b/client/src/components/SpectrogramViewer.vue
@@ -35,14 +35,14 @@ export default defineComponent({
       blackBackground,
       scaledVals,
       configuration,
+      scaledWidth,
+      scaledHeight
     } = useState();
 
     const containerRef: Ref<HTMLElement | undefined> = ref();
     const geoJS = useGeoJS();
     const initialized = ref(false);
     const cursor = ref("");
-    const scaledWidth = ref(0);
-    const scaledHeight = ref(0);
     const imageCursorRef: Ref<HTMLElement | undefined> = ref();
 
     const setCursor = (newCursor: string) => { cursor.value = newCursor; };

--- a/client/src/components/ThumbnailViewer.vue
+++ b/client/src/components/ThumbnailViewer.vue
@@ -115,7 +115,6 @@ export default defineComponent({
           props.parentGeoViewerRef.value.zoom(props.parentGeoViewerRef.value.zoom());
         }
         const size = parent.size();
-        const { top } = parent.bounds();
         outlineFeature.style(outlineStyle);
         const polygon = [[
           parent.displayToGcs({ x: 0, y: 0 }),
@@ -134,7 +133,7 @@ export default defineComponent({
 
     watch([() => props.spectroInfo, containerRef], updateViewerAndImages);
 
-        watch([scaledHeight, scaledWidth], () => {
+    watch([scaledHeight, scaledWidth], () => {
       geoJS.resetMapDimensions(scaledWidth.value, scaledHeight.value);
       geoJS.getGeoViewer().value.bounds({
         left: 0,

--- a/client/src/components/ThumbnailViewer.vue
+++ b/client/src/components/ThumbnailViewer.vue
@@ -57,7 +57,7 @@ export default defineComponent({
       yScale.value = diff ? (clientHeight.value * 0.5) / diff : 1;
 
       if (props.images.length) {
-        geoJS.drawImages(props.images, scaledWidth.value, scaledHeight.value, false);
+        geoJS.drawImages(props.images, scaledWidth.value || width, scaledHeight.value || height);
       }
       initialized.value = true;
       nextTick(() => createPolyLayer());
@@ -134,15 +134,16 @@ export default defineComponent({
     watch([() => props.spectroInfo, containerRef], updateViewerAndImages);
 
     watch([scaledHeight, scaledWidth], () => {
-      geoJS.resetMapDimensions(scaledWidth.value, scaledHeight.value);
+      const { width, height } = getImageDimensions(props.images);
+      geoJS.resetMapDimensions(scaledWidth.value || width, scaledHeight.value || height);
       geoJS.getGeoViewer().value.bounds({
         left: 0,
         top: 0,
-        bottom: scaledHeight.value,
-        right: scaledWidth.value,
+        bottom: scaledHeight.value || height,
+        right: scaledWidth.value || width,
       });
       if (props.images.length) {
-        geoJS.drawImages(props.images, scaledWidth.value, scaledHeight.value);
+        geoJS.drawImages(props.images, scaledWidth.value || width, scaledHeight.value | height);
       }
     });
 

--- a/client/src/components/geoJS/LayerManager.vue
+++ b/client/src/components/geoJS/LayerManager.vue
@@ -540,16 +540,20 @@ export default defineComponent({
     });
     watch([() => props.scaledWidth, () => props.scaledHeight], () => {
       const { annotations, temporalAnnotations } = getDataForLayers();
-      legendLayer.setScaledDimensions(props.scaledWidth, props.scaledHeight);
-      rectAnnotationLayer.setScaledDimensions(props.scaledWidth, props.scaledHeight);
-      rectAnnotationLayer.formatData(
-        annotations,
-        selectedType.value === 'pulse' ? selectedAnnotationId.value : null,
-        currentUser.value,
-        colorScale.value,
-        props.yScale,
-      );
-      rectAnnotationLayer.redraw();
+      if (legendLayer) {
+        legendLayer.setScaledDimensions(props.scaledWidth, props.scaledHeight);
+      }
+      if (rectAnnotationLayer) {
+        rectAnnotationLayer.setScaledDimensions(props.scaledWidth, props.scaledHeight);
+        rectAnnotationLayer.formatData(
+          annotations,
+          selectedType.value === 'pulse' ? selectedAnnotationId.value : null,
+          currentUser.value,
+          colorScale.value,
+          props.yScale,
+        );
+        rectAnnotationLayer.redraw();
+      }
       if (compressedOverlayLayer && props.spectroInfo?.start_times && props.spectroInfo.end_times && viewCompressedOverlay.value) {
         compressedOverlayLayer.setScaledDimensions(props.scaledWidth, props.scaledHeight);
         compressedOverlayLayer.formatData(props.spectroInfo.start_times, props.spectroInfo.end_times, props.yScale);
@@ -561,31 +565,32 @@ export default defineComponent({
           editAnnotationLayer.changeData(editingAnnotation.value, selectedType.value);
         }, 0);
       }
-      timeLayer.setScaledDimensions(props.scaledWidth, props.scaledHeight);
-      freqLayer.setScaledDimensions(props.scaledWidth, props.scaledHeight);
-      speciesLayer.setScaledDimensions(props.scaledWidth, props.scaledHeight);
-      speciesSequenceLayer.setScaledDimensions(props.scaledWidth, props.scaledHeight);
-      temporalAnnotationLayer.setScaledDimensions(props.scaledWidth, props.scaledHeight);
-      if (layerVisibility.value.includes("time")) {
+
+      timeLayer?.setScaledDimensions(props.scaledWidth, props.scaledHeight);
+      freqLayer?.setScaledDimensions(props.scaledWidth, props.scaledHeight);
+      speciesLayer?.setScaledDimensions(props.scaledWidth, props.scaledHeight);
+      speciesSequenceLayer?.setScaledDimensions(props.scaledWidth, props.scaledHeight);
+      temporalAnnotationLayer?.setScaledDimensions(props.scaledWidth, props.scaledHeight);
+      if (timeLayer && layerVisibility.value.includes("time")) {
         timeLayer.formatData(annotations, temporalAnnotations);
         timeLayer.redraw();
       } else {
-        timeLayer.disable();
+        timeLayer?.disable();
       }
-      if (layerVisibility.value.includes("freq")) {
+      if (freqLayer && layerVisibility.value.includes("freq")) {
         freqLayer.formatData(annotations);
         freqLayer.redraw();
       } else {
-        freqLayer.disable();
+        freqLayer?.disable();
       }
-      if (layerVisibility.value.includes("species")) {
+      if (speciesLayer && speciesSequenceLayer && layerVisibility.value.includes("species")) {
         speciesLayer.formatData(annotations);
         speciesLayer.redraw();
         speciesSequenceLayer.formatData(temporalAnnotations);
         speciesSequenceLayer.redraw();
       } else {
-        speciesLayer.disable();
-        speciesSequenceLayer.disable();
+        speciesLayer?.disable();
+        speciesSequenceLayer?.disable();
       }
       if (temporalAnnotationLayer && layerVisibility.value.includes('temporal')) {
         temporalAnnotationLayer.formatData(
@@ -597,7 +602,7 @@ export default defineComponent({
         );
       }
       // Triggers the Axis redraw when zoomed in and the axis is at the bottom/top
-      legendLayer.onPan();
+      legendLayer?.onPan();
     });
     watch(viewCompressedOverlay, () => {
       if (viewCompressedOverlay.value && compressedOverlayLayer && props.spectroInfo?.start_times && props.spectroInfo.end_times) {
@@ -626,6 +631,10 @@ export default defineComponent({
     const bValues = ref('');
 
     function updateColorFilter() {
+      if (!backgroundColor.value.includes(',')) {
+        // convert rgb(0 0 0) to rgb(0, 0, 0)
+        backgroundColor.value = backgroundColor.value.replace(/rgb\((\d+)\s+(\d+)\s+(\d+)\)/, 'rgb($1, $2, $3)');
+      }
       const backgroundRgbColor = d3.color(backgroundColor.value) as d3.RGBColor;
       const redStops: number[] = [backgroundRgbColor.r / 255];
       const greenStops: number[] = [backgroundRgbColor.g / 255];

--- a/client/src/components/geoJS/LayerManager.vue
+++ b/client/src/components/geoJS/LayerManager.vue
@@ -559,7 +559,7 @@ export default defineComponent({
         compressedOverlayLayer.formatData(props.spectroInfo.start_times, props.spectroInfo.end_times, props.yScale);
         compressedOverlayLayer.redraw();
       }
-      editAnnotationLayer.setScaledDimensions(props.scaledWidth, props.scaledHeight);
+      editAnnotationLayer?.setScaledDimensions(props.scaledWidth, props.scaledHeight);
       if (editing.value && editingAnnotation.value) {
         setTimeout(() => {
           editAnnotationLayer.changeData(editingAnnotation.value, selectedType.value);

--- a/client/src/components/geoJS/geoJSUtils.ts
+++ b/client/src/components/geoJS/geoJSUtils.ts
@@ -45,7 +45,7 @@ const useGeoJS = () => {
     width: number,
     height: number,
     thumbnailVal = false,
-    imageCount = 1,
+    imageCount = 1
   ) => {
     thumbnail.value = thumbnailVal;
     container.value = sourceContainer;
@@ -125,31 +125,31 @@ const useGeoJS = () => {
     }
   };
 
-
   const drawImages = (images: HTMLImageElement[], width = 0, height = 0, resetCam = true) => {
     let previousWidth = 0;
     let totalBaseWidth = 0;
-    images.forEach((image) => totalBaseWidth += image.naturalWidth);
+    images.forEach((image) => (totalBaseWidth += image.naturalWidth));
     images.forEach((image, index) => {
       const scaledWidth = width / totalBaseWidth;
-      const currentWidth =  image.width * scaledWidth;
-      quadFeatures[index].data([
-        {
-          ul: { x: previousWidth, y: 0 },
-          lr: { x: previousWidth + currentWidth, y: height },
-          image: image,
-        },
-      ]).draw();
+      const currentWidth = image.width * scaledWidth;
+      if (quadFeatures[index] === undefined) {
+        quadFeatures[index] = quadFeatureLayer.createFeature("quad");
+      }
+      quadFeatures[index]
+        .data([
+          {
+            ul: { x: previousWidth, y: 0 },
+            lr: { x: previousWidth + currentWidth, y: height },
+            image: image,
+          },
+        ])
+        .draw();
       previousWidth += currentWidth;
     });
     if (resetCam) {
       resetMapDimensions(width, height, 0.3, resetCam);
     } else {
-      const params = geo.util.pixelCoordinateParams(
-        container.value,
-        width,
-        height,
-      );
+      const params = geo.util.pixelCoordinateParams(container.value, width, height);
       const margin = 0.3;
       const { right, bottom } = params.map.maxBounds;
       originalBounds = params.map.maxBounds;

--- a/client/src/use/useState.ts
+++ b/client/src/use/useState.ts
@@ -3,11 +3,11 @@ import { cloneDeep } from "lodash";
 import * as d3 from "d3";
 import {
   Configuration,
-	getConfiguration,
-	OtherUserAnnotations,
-	Recording,
-	SpectrogramAnnotation,
-	SpectrogramTemporalAnnotation,
+  getConfiguration,
+  OtherUserAnnotations,
+  Recording,
+  SpectrogramAnnotation,
+  SpectrogramTemporalAnnotation,
 } from "../api/api";
 import {
   interpolateCividis,
@@ -19,24 +19,26 @@ import {
 } from "d3-scale-chromatic";
 
 const annotationState: Ref<AnnotationState> = ref("");
-const creationType: Ref<'pulse' | 'sequence'> = ref("pulse");
-type LayersVis = "time" | "freq" | "species" | "grid" | 'temporal' | 'duration';
-const layerVisibility: Ref<LayersVis[]> = ref(['temporal', 'species', 'duration', 'freq']);
+const creationType: Ref<"pulse" | "sequence"> = ref("pulse");
+type LayersVis = "time" | "freq" | "species" | "grid" | "temporal" | "duration";
+const layerVisibility: Ref<LayersVis[]> = ref(["temporal", "species", "duration", "freq"]);
 const colorScale: Ref<d3.ScaleOrdinal<string, string, never> | undefined> = ref();
 const colorSchemes = [
-  { value: 'inferno', title: 'Inferno', scheme: interpolateInferno },
-  { value: 'cividis', title: 'Cividis', scheme: interpolateCividis },
-  { value: 'viridis', title: 'Viridis', scheme: interpolateViridis },
-  { value: 'magma', title: 'Magma', scheme: interpolateMagma },
-  { value: 'plasma', title: 'Plasma', scheme: interpolatePlasma },
-  { value: 'turbo', title: 'Turbo', scheme: interpolateTurbo },
+  { value: "inferno", title: "Inferno", scheme: interpolateInferno },
+  { value: "cividis", title: "Cividis", scheme: interpolateCividis },
+  { value: "viridis", title: "Viridis", scheme: interpolateViridis },
+  { value: "magma", title: "Magma", scheme: interpolateMagma },
+  { value: "plasma", title: "Plasma", scheme: interpolatePlasma },
+  { value: "turbo", title: "Turbo", scheme: interpolateTurbo },
 ];
-const colorScheme: Ref<{ value: string, title: string, scheme: (input: number) => string }> = ref(colorSchemes[0]);
-const backgroundColor = ref('rgb(0, 0, 0)');
+const colorScheme: Ref<{ value: string; title: string; scheme: (input: number) => string }> = ref(
+  colorSchemes[0]
+);
+const backgroundColor = ref("rgb(0, 0, 0)");
 const selectedUsers: Ref<string[]> = ref([]);
-const currentUser: Ref<string> = ref('');
+const currentUser: Ref<string> = ref("");
 const selectedId: Ref<number | null> = ref(null);
-const selectedType: Ref<'pulse' | 'sequence'> = ref('pulse');
+const selectedType: Ref<"pulse" | "sequence"> = ref("pulse");
 const annotations: Ref<SpectrogramAnnotation[]> = ref([]);
 const temporalAnnotations: Ref<SpectrogramTemporalAnnotation[]> = ref([]);
 const otherUserAnnotations: Ref<OtherUserAnnotations> = ref({});
@@ -44,19 +46,21 @@ const sharedList: Ref<Recording[]> = ref([]);
 const recordingList: Ref<Recording[]> = ref([]);
 const nextShared: Ref<Recording | false> = ref(false);
 const blackBackground = ref(true);
-const scaledVals: Ref<{ x: number, y: number }> = ref({ x: 1, y: 1 });
+const scaledVals: Ref<{ x: number; y: number }> = ref({ x: 1, y: 1 });
 const viewCompressedOverlay = ref(false);
-const sideTab: Ref<'annotations' | 'recordings'> = ref('annotations');
+const sideTab: Ref<"annotations" | "recordings"> = ref("annotations");
 const configuration: Ref<Configuration> = ref({
   display_pulse_annotations: true,
   display_sequence_annotations: true,
-  spectrogram_view: 'compressed',
+  spectrogram_view: "compressed",
   spectrogram_x_stretch: 2.5,
   run_inference_on_upload: true,
-  default_color_scheme: 'inferno',
-  default_spectrogram_background_color: 'rgb(0, 0, 0)',
+  default_color_scheme: "inferno",
+  default_spectrogram_background_color: "rgb(0, 0, 0)",
   is_admin: false,
 });
+const scaledWidth = ref(0);
+const scaledHeight = ref(0);
 
 type AnnotationState = "" | "editing" | "creating" | "disabled";
 export default function useState() {
@@ -73,12 +77,12 @@ export default function useState() {
       // If the value is present, remove it
       clone.splice(index, 1);
     }
-    if (value === 'time' && clone.includes('duration')) {
-      const durationInd = layerVisibility.value.indexOf('duration');
+    if (value === "time" && clone.includes("duration")) {
+      const durationInd = layerVisibility.value.indexOf("duration");
       clone.splice(durationInd, 1);
     }
-    if (value === 'duration' && clone.includes('time')) {
-      const timeInd = layerVisibility.value.indexOf('time');
+    if (value === "duration" && clone.includes("time")) {
+      const timeInd = layerVisibility.value.indexOf("time");
       clone.splice(timeInd, 1);
     }
     layerVisibility.value = clone;
@@ -88,13 +92,17 @@ export default function useState() {
   };
 
   function createColorScale(userEmails: string[]) {
-    colorScale.value = d3.scaleOrdinal<string>()
+    colorScale.value = d3
+      .scaleOrdinal<string>()
       .domain(userEmails)
-      .range(d3.schemeCategory10.filter(color => color !== 'red' && color !== 'cyan' && color !== 'yellow'));
-
+      .range(
+        d3.schemeCategory10.filter(
+          (color) => color !== "red" && color !== "cyan" && color !== "yellow"
+        )
+      );
   }
 
-  function setSelectedId(id: number | null, annotationType?: 'pulse' | 'sequence') {
+  function setSelectedId(id: number | null, annotationType?: "pulse" | "sequence") {
     selectedId.value = id;
     if (annotationType) {
       selectedType.value = annotationType;
@@ -143,5 +151,7 @@ export default function useState() {
     scaledVals,
     viewCompressedOverlay,
     sideTab,
+    scaledWidth,
+    scaledHeight,
   };
 }


### PR DESCRIPTION
resolves #213 
- The Vuetify return for RGB values has seemed to switch from `rgb(0, 0, 0)` to something like `rgb(0 0 0)`.  So I added some regex to inject the commas so that `d3.color()` will properly interpret the color.
- Transferred the `scaledWidth` and the `scaledHeight` to `useState` so it can be shared between the SpectrogramViewer and the ThumbnailViewer
- LayerManager needed some updates to conditional render layers that the thumbnail layer doesn't have like the legendLayer or timeLayer.
- The calculation for the thumbnail layer was complicated before I fixed how X/Y scaling worked.  So I updated it to use the proper end coordinates and it should better line up with the current view.
