### PR TITLE
Address UI Feedback

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -113,7 +113,7 @@ export default defineComponent({
         v-if="isNaBat"
         class="mx-3"
       >
-        NA Bat Spectrogram Viewer
+        NABat Spectrogram Viewer
       </h3>
       <v-spacer />
       <v-tooltip

--- a/client/src/components/RecordingAnnotationDetails.vue
+++ b/client/src/components/RecordingAnnotationDetails.vue
@@ -52,7 +52,7 @@ export default defineComponent({
         <v-data-table
           :headers="[
             { title: 'Label', value: 'label', sortable: true },
-            { title: 'Value', value: 'value', sortable: true }
+            { title: 'Confidence', value: 'value', sortable: true }
           ]"
           :items="annotationData.confidences"
           :items-per-page="-1"

--- a/client/src/components/RecordingAnnotationEditor.vue
+++ b/client/src/components/RecordingAnnotationEditor.vue
@@ -84,7 +84,7 @@ export default defineComponent({
 
     };
 
-    
+
 
     const deleteAnnotation = async () => {
       if (props.annotation && props.recordingId) {
@@ -108,7 +108,25 @@ export default defineComponent({
   <v-card>
     <v-card-title>
       <v-row class="pa-2">
-        Choose Labels
+        Choose Label
+        <v-tooltip
+          v-if="type === 'nabat'"
+          width="250"
+          right
+        >
+          <template #activator="{ props }">
+            <v-icon
+              v-bind="props"
+              size="x-small"
+            >
+              mdi-information
+            </v-icon>
+          </template>
+          <span>
+            Each user may only add one label per file. Once you have saved
+            your selection it may not be deleted.
+          </span>
+        </v-tooltip>
         <v-spacer />
         <v-btn
           v-if="type !== 'nabat'"
@@ -167,7 +185,7 @@ export default defineComponent({
           @change="updateAnnotation()"
         />
       </v-row>
-    </v-card-text> 
+    </v-card-text>
   </v-card>
 </template>
 

--- a/client/src/components/RecordingAnnotations.vue
+++ b/client/src/components/RecordingAnnotations.vue
@@ -38,7 +38,7 @@ export default defineComponent({
     const annotations: Ref<FileAnnotation[]> = ref([]);
     const detailsDialog = ref(false);
     const detailRecordingId = ref(-1);
-    const { configuration } = useState();
+    const { configuration, isNaBat } = useState();
 
     const setSelectedId = (annotation: FileAnnotation) => {
       selectedAnnotation.value = annotation;
@@ -129,6 +129,7 @@ export default defineComponent({
       updatedAnnotation,
       loadDetails,
       getConfidenceLabelText,
+      isNaBat,
       detailsDialog,
       detailRecordingId,
       disableNaBatAnnotations,
@@ -140,12 +141,12 @@ export default defineComponent({
 
 <template>
   <div>
-    <v-row class="pa-2">
-      <v-col>
+    <v-row class="pa-4">
+      <v-col v-if="!isNaBat()">
         Annotations
       </v-col>
       <v-spacer />
-      <v-col>
+      <v-col v-if="!isNaBat() || !disableNaBatAnnotations">
         <v-btn
           :disabled="annotationState === 'creating' || disableNaBatAnnotations"
           @click="addAnnotation()"

--- a/client/src/components/RecordingAnnotations.vue
+++ b/client/src/components/RecordingAnnotations.vue
@@ -46,7 +46,7 @@ export default defineComponent({
 
     const currentNaBatUser: Ref<string | null> = ref(null);
 
-    
+
 
     const loadFileAnnotations = async () => {
       if (props.type === 'nabat') {
@@ -116,6 +116,10 @@ export default defineComponent({
       return ( currentUserAnnotations.length > 0 && props.type === 'nabat');
     });
 
+    function getConfidenceLabelText(confidence: number) {
+      return `Confidence: ${confidence.toFixed(2)}`;
+    }
+
     return {
       selectedAnnotation,
       annotationState,
@@ -124,6 +128,7 @@ export default defineComponent({
       addAnnotation,
       updatedAnnotation,
       loadDetails,
+      getConfidenceLabelText,
       detailsDialog,
       detailRecordingId,
       disableNaBatAnnotations,
@@ -172,7 +177,7 @@ export default defineComponent({
             </v-btn>
           </v-col>
           <v-col class="annotation-confidence">
-            <span>{{ annotation.confidence }} </span>
+            <span>{{ getConfidenceLabelText(annotation.confidence) }} </span>
           </v-col>
           <v-col class="annotation-model">
             <span>{{ annotation.model }} </span>

--- a/client/src/components/geoJS/layers/legendLayer.ts
+++ b/client/src/components/geoJS/layers/legendLayer.ts
@@ -201,7 +201,7 @@ export default class LegendLayer {
         const width = this.scaledWidth > compressedWidth ? (this.scaledWidth / compressedWidth) * widths[i] : widths[i];
         const bottomWithinYAxisStart = (pixelOffset) < (leftOffset +  50)  && leftOffset !== 0 && yOffset !== 0;
         const topWithinYAxisEnd = (pixelOffset+width) < (leftOffset +  50)  && leftOffset !== 0 && topOffset !== 0;
-
+     
 
       if (!bottomWithinYAxisStart) {
         this.lineDataX.push({
@@ -232,7 +232,7 @@ export default class LegendLayer {
           },
           thicker: true,
         });
-
+      
         this.lineDataX.push({
           line: {
             type: "LineString",
@@ -362,20 +362,11 @@ export default class LegendLayer {
         },
         thicker: i % 10000 === 0,
       });
-      const getTextXOffset = (rightOrLeft: number, frequency: number) => {
-        const multiplier = rightOrLeft === 0 ? -1 : 1;
-        if (frequency >= 100000) {
-          return 40 * multiplier;
-        } else if (frequency >= 10000) {
-          return 35 * multiplier;
-        }
-        return 30 * multiplier;
-      };
       this.textDataY.push({
         text: `${(i + this.spectroInfo.low_freq) / 1000}KHz`,
         x: offset - xBuffer - length,
         y: adjustedHeight - i * hzToPixels,
-        offsetX: getTextXOffset(offset, i + this.spectroInfo.low_freq),
+        offsetX: offset === 0 ? -25 : 25,
         offsetY: 0,
       });
     }

--- a/client/src/components/geoJS/layers/legendLayer.ts
+++ b/client/src/components/geoJS/layers/legendLayer.ts
@@ -201,7 +201,7 @@ export default class LegendLayer {
         const width = this.scaledWidth > compressedWidth ? (this.scaledWidth / compressedWidth) * widths[i] : widths[i];
         const bottomWithinYAxisStart = (pixelOffset) < (leftOffset +  50)  && leftOffset !== 0 && yOffset !== 0;
         const topWithinYAxisEnd = (pixelOffset+width) < (leftOffset +  50)  && leftOffset !== 0 && topOffset !== 0;
-     
+
 
       if (!bottomWithinYAxisStart) {
         this.lineDataX.push({
@@ -232,7 +232,7 @@ export default class LegendLayer {
           },
           thicker: true,
         });
-      
+
         this.lineDataX.push({
           line: {
             type: "LineString",
@@ -362,11 +362,20 @@ export default class LegendLayer {
         },
         thicker: i % 10000 === 0,
       });
+      const getTextXOffset = (rightOrLeft: number, frequency: number) => {
+        const multiplier = rightOrLeft === 0 ? -1 : 1;
+        if (frequency >= 100000) {
+          return 40 * multiplier;
+        } else if (frequency >= 10000) {
+          return 35 * multiplier;
+        }
+        return 30 * multiplier;
+      };
       this.textDataY.push({
         text: `${(i + this.spectroInfo.low_freq) / 1000}KHz`,
         x: offset - xBuffer - length,
         y: adjustedHeight - i * hzToPixels,
-        offsetX: offset === 0 ? -25 : 25,
+        offsetX: getTextXOffset(offset, i + this.spectroInfo.low_freq),
         offsetY: 0,
       });
     }

--- a/client/src/use/useState.ts
+++ b/client/src/use/useState.ts
@@ -1,4 +1,5 @@
 import { ref, Ref, watch } from "vue";
+import { useRouter } from 'vue-router';
 import { cloneDeep } from "lodash";
 import * as d3 from "d3";
 import {
@@ -121,6 +122,17 @@ export default function useState() {
     configuration.value = (await getConfiguration()).data;
   }
 
+  /**
+   * Function used to determine whether or not we are currently looking
+   * at an NABat-specific view.
+   *
+   * returns `true` if looking at an NABat view, `false` otherwise
+   */
+  function isNaBat(): boolean {
+    const router = useRouter();
+    return router.currentRoute.value.fullPath.includes('nabat');
+  }
+
   return {
     annotationState,
     creationType,
@@ -137,6 +149,7 @@ export default function useState() {
     currentUser,
     setSelectedId,
     loadConfiguration,
+    isNaBat,
     // State Passing Elements
     annotations,
     configuration,


### PR DESCRIPTION
Fix #210 

- [x] Title in the Top left should be ' NABat Spectrogram Viewer' without a space between NA and Bat. Or we should get an official NABat logo from USGS to update for this area
- [x] Frequencies on the Y axis with more than 3 digits spill over onto the dash immediately to the right of it even on large monitors
- [ ] ~When I adjust scaling in the app in compressed view so axes are 1:1 timestamps are often overlapping and unreadable.~ (Note that I believe this is being addressed in #230, please confirm @BryonLewis)
- [ ] ~Help button serves up outdated information. This should be updated so it is accurate.~ **UPDATE:** this will not be addressed as part of this PR. See #232 and #233 to track this going forward.
- [x] Species info table should include scientific name (fixed by #222)
- [x] Species info table has columns for family and genus but they are blank. These can be removed. (fixed by #222)
- [x] Various label changes (see images in issue #210)
