### PR TITLE
Add a bounding box tool for NABat spectrograms

### DIFF
--- a/client/src/components/geoJS/LayerManager.vue
+++ b/client/src/components/geoJS/LayerManager.vue
@@ -2,7 +2,12 @@
 import { defineComponent, nextTick, onMounted, onUnmounted, PropType, Ref, ref, watch } from "vue";
 import * as d3 from "d3";
 import { SpectrogramAnnotation, SpectrogramSequenceAnnotation } from "../../api/api";
-import { geojsonToSpectro, SpectroInfo, textColorFromBackground } from "./geoJSUtils";
+import {
+  annotationSpreadAcrossPulsesWarning,
+  geojsonToSpectro,
+  SpectroInfo,
+  textColorFromBackground,
+} from "./geoJSUtils";
 import EditAnnotationLayer from "./layers/editAnnotationLayer";
 import RectangleLayer from "./layers/rectangleLayer";
 import CompressedOverlayLayer from "./layers/compressedOverlayLayer";
@@ -236,7 +241,7 @@ export default defineComponent({
             if (index !== -1 && props.spectroInfo && selectedType.value === 'sequence') {
               // update bounds for the localAnnotation
               const conversionResult = geojsonToSpectro(geoJSON, props.spectroInfo, props.scaledWidth, props.scaledHeight);
-              if (conversionResult.warning) {
+              if (conversionResult.warning && conversionResult.warning !== annotationSpreadAcrossPulsesWarning) {
                 displayError.value = true;
                 errorMsg.value = conversionResult.warning;
                 return;
@@ -257,7 +262,9 @@ export default defineComponent({
           if (geoJSON && props.spectroInfo) {
             const conversionResult = geojsonToSpectro(geoJSON, props.spectroInfo, props.scaledWidth, props.scaledHeight);
 
-            if (conversionResult.warning) {
+            if (conversionResult.warning
+              && !(creationType.value === 'sequence' && conversionResult.warning === annotationSpreadAcrossPulsesWarning)
+            ) {
               displayError.value = true;
               errorMsg.value = conversionResult.warning;
               return;

--- a/client/src/components/geoJS/LayerManager.vue
+++ b/client/src/components/geoJS/LayerManager.vue
@@ -68,6 +68,7 @@ export default defineComponent({
       measuring,
       frequencyRulerY,
       drawingBoundingBox,
+      isNaBat,
     } = useState();
     const selectedAnnotationId: Ref<null | number> = ref(null);
     const hoveredAnnotationId: Ref<null | number> = ref(null);
@@ -540,11 +541,12 @@ export default defineComponent({
             }
           });
 
-          if (!boundingBoxLayer) {
+          if (isNaBat() && !boundingBoxLayer) {
             boundingBoxLayer = new BoundingBoxLayer(props.geoViewerRef, event, props.spectroInfo, drawingBoundingBox.value);
             boundingBoxLayer.setScaledDimensions(props.scaledWidth, props.scaledHeight);
           }
           watch(drawingBoundingBox, () => {
+            if (!isNaBat) return;
             if (drawingBoundingBox.value) {
               boundingBoxLayer.enableDrawing();
             } else {
@@ -729,7 +731,7 @@ export default defineComponent({
       if (measureToolLayer) {
         measureToolLayer.setTextColor(textColor);
       }
-      if (boundingBoxLayer) {
+      if (isNaBat() && boundingBoxLayer) {
         boundingBoxLayer.setTextColor(textColor);
       }
     }

--- a/client/src/components/geoJS/LayerManager.vue
+++ b/client/src/components/geoJS/LayerManager.vue
@@ -610,7 +610,7 @@ export default defineComponent({
           compressedOverlayLayer.formatData(props.spectroInfo.start_times, props.spectroInfo.end_times, props.yScale);
           compressedOverlayLayer.redraw();
         } else {
-          compressedOverlayLayer?.disable(); 
+          compressedOverlayLayer?.disable();
         }
       }
       editAnnotationLayer?.setScaledDimensions(props.scaledWidth, props.scaledHeight);
@@ -731,7 +731,7 @@ export default defineComponent({
       if (measureToolLayer) {
         measureToolLayer.setTextColor(textColor);
       }
-      if (isNaBat() && boundingBoxLayer) {
+      if (boundingBoxLayer) {
         boundingBoxLayer.setTextColor(textColor);
       }
     }

--- a/client/src/components/geoJS/LayerManager.vue
+++ b/client/src/components/geoJS/LayerManager.vue
@@ -68,7 +68,6 @@ export default defineComponent({
       measuring,
       frequencyRulerY,
       drawingBoundingBox,
-      isNaBat,
     } = useState();
     const selectedAnnotationId: Ref<null | number> = ref(null);
     const hoveredAnnotationId: Ref<null | number> = ref(null);
@@ -541,12 +540,11 @@ export default defineComponent({
             }
           });
 
-          if (isNaBat() && !boundingBoxLayer) {
+          if (!boundingBoxLayer) {
             boundingBoxLayer = new BoundingBoxLayer(props.geoViewerRef, event, props.spectroInfo, drawingBoundingBox.value);
             boundingBoxLayer.setScaledDimensions(props.scaledWidth, props.scaledHeight);
           }
           watch(drawingBoundingBox, () => {
-            if (!isNaBat) return;
             if (drawingBoundingBox.value) {
               boundingBoxLayer.enableDrawing();
             } else {

--- a/client/src/components/geoJS/LayerManager.vue
+++ b/client/src/components/geoJS/LayerManager.vue
@@ -68,6 +68,7 @@ export default defineComponent({
       measuring,
       frequencyRulerY,
       drawingBoundingBox,
+      boundingBoxError,
     } = useState();
     const selectedAnnotationId: Ref<null | number> = ref(null);
     const hoveredAnnotationId: Ref<null | number> = ref(null);
@@ -294,6 +295,10 @@ export default defineComponent({
       if (type === "measure:dragged") {
         const { yValue } = data;
         frequencyRulerY.value = yValue || 0;
+      }
+      if (type === "bbox:error") {
+        const { error } = data;
+        boundingBoxError.value = error || '';
       }
     };
 

--- a/client/src/components/geoJS/LayerManager.vue
+++ b/client/src/components/geoJS/LayerManager.vue
@@ -218,9 +218,9 @@ export default defineComponent({
             if (index !== -1 && props.spectroInfo && selectedType.value === 'pulse') {
               // update bounds for the localAnnotation
               const conversionResult = geojsonToSpectro(geoJSON, props.spectroInfo, props.scaledWidth, props.scaledHeight);
-              if (conversionResult.error) {
+              if (conversionResult.warning) {
                 displayError.value = true;
-                errorMsg.value = conversionResult.error;
+                errorMsg.value = conversionResult.warning;
                 return;
               }
               const { low_freq, high_freq, start_time, end_time } = conversionResult;
@@ -236,9 +236,9 @@ export default defineComponent({
             if (index !== -1 && props.spectroInfo && selectedType.value === 'sequence') {
               // update bounds for the localAnnotation
               const conversionResult = geojsonToSpectro(geoJSON, props.spectroInfo, props.scaledWidth, props.scaledHeight);
-              if (conversionResult.error) {
+              if (conversionResult.warning) {
                 displayError.value = true;
-                errorMsg.value = conversionResult.error;
+                errorMsg.value = conversionResult.warning;
                 return;
               }
               const { start_time, end_time } = conversionResult;
@@ -257,9 +257,9 @@ export default defineComponent({
           if (geoJSON && props.spectroInfo) {
             const conversionResult = geojsonToSpectro(geoJSON, props.spectroInfo, props.scaledWidth, props.scaledHeight);
 
-            if (conversionResult.error) {
+            if (conversionResult.warning) {
               displayError.value = true;
-              errorMsg.value = conversionResult.error;
+              errorMsg.value = conversionResult.warning;
               return;
             }
             const { low_freq, high_freq, start_time, end_time } = conversionResult;

--- a/client/src/components/geoJS/LayerManager.vue
+++ b/client/src/components/geoJS/LayerManager.vue
@@ -13,6 +13,7 @@ import FreqLayer from "./layers/freqLayer";
 import SpeciesLayer from "./layers/speciesLayer";
 import SpeciesSequenceLayer from "./layers/speciesSequenceLayer";
 import MeasureToolLayer from "./layers/measureToolLayer";
+import BoundingBoxLayer from "./layers/boundingBoxLayer";
 import { cloneDeep } from "lodash";
 import useState from "@use/useState";
 export default defineComponent({
@@ -66,6 +67,7 @@ export default defineComponent({
       backgroundColor,
       measuring,
       frequencyRulerY,
+      drawingBoundingBox,
     } = useState();
     const selectedAnnotationId: Ref<null | number> = ref(null);
     const hoveredAnnotationId: Ref<null | number> = ref(null);
@@ -83,6 +85,7 @@ export default defineComponent({
     let speciesLayer: SpeciesLayer;
     let speciesSequenceLayer: SpeciesSequenceLayer;
     let measureToolLayer: MeasureToolLayer;
+    let boundingBoxLayer: BoundingBoxLayer;
     const displayError = ref(false);
     const errorMsg = ref("");
 
@@ -537,6 +540,18 @@ export default defineComponent({
             }
           });
 
+          if (!boundingBoxLayer) {
+            boundingBoxLayer = new BoundingBoxLayer(props.geoViewerRef, event, props.spectroInfo, drawingBoundingBox.value);
+            boundingBoxLayer.setScaledDimensions(props.scaledWidth, props.scaledHeight);
+          }
+          watch(drawingBoundingBox, () => {
+            if (drawingBoundingBox.value) {
+              boundingBoxLayer.enableDrawing();
+            } else {
+              boundingBoxLayer.disableDrawing();
+            }
+          });
+
           timeLayer.setDisplaying({ pulse: configuration.value.display_pulse_annotations, sequence: configuration.value.display_sequence_annotations });
           timeLayer.formatData(localAnnotations.value, sequenceAnnotations.value);
           freqLayer.formatData(localAnnotations.value);
@@ -713,6 +728,9 @@ export default defineComponent({
       }
       if (measureToolLayer) {
         measureToolLayer.setTextColor(textColor);
+      }
+      if (boundingBoxLayer) {
+        boundingBoxLayer.setTextColor(textColor);
       }
     }
 

--- a/client/src/components/geoJS/geoJSUtils.ts
+++ b/client/src/components/geoJS/geoJSUtils.ts
@@ -506,7 +506,7 @@ function geojsonToSpectro(
   spectroInfo: SpectroInfo,
   scaledWidth = 0,
   scaledHeight = 0,
-): { error?: string; start_time: number; end_time: number; low_freq: number; high_freq: number } {
+): { warning?: string; start_time: number; end_time: number; low_freq: number; high_freq: number } {
   const adjustedWidth = scaledWidth > spectroInfo.width ? scaledWidth : spectroInfo.width;
   const adjustedHeight = scaledHeight > spectroInfo.height ? scaledHeight : spectroInfo.height;
 
@@ -579,7 +579,7 @@ function geojsonToSpectro(
     if (warn) {
       // the time spreads across multiple pulses and isn't allowed;
       return {
-        error:
+        warning:
           "Start or End Time spread across pulses.  This is not allowed in compressed annotations",
         start_time,
         end_time,

--- a/client/src/components/geoJS/geoJSUtils.ts
+++ b/client/src/components/geoJS/geoJSUtils.ts
@@ -648,6 +648,14 @@ function textColorFromBackground(rgbString: string): "black" | "white" {
   return getContrastingColor(r, g, b);
 }
 
+/**
+ * correct matching of drag handle to cursor direction relies on strict ordering of
+ * vertices within the GeoJSON coordinate list using utils.reOrdergeoJSON()
+ * and utils.reOrderBounds()
+ */
+const rectVertex = ["sw-resize", "nw-resize", "ne-resize", "se-resize"];
+const rectEdge = ["w-resize", "n-resize", "e-resize", "s-resize"];
+
 export {
   spectroToGeoJSon,
   geojsonToSpectro,
@@ -655,5 +663,7 @@ export {
   useGeoJS,
   spectroToCenter,
   spectroSequenceToGeoJSon,
-  textColorFromBackground
+  textColorFromBackground,
+  rectVertex,
+  rectEdge,
 };

--- a/client/src/components/geoJS/geoJSUtils.ts
+++ b/client/src/components/geoJS/geoJSUtils.ts
@@ -543,6 +543,9 @@ function geojsonToSpectro(
     let additivePixels = 0;
     let start_time = -1;
     let end_time = -1;
+    let warn = false;
+    let startIndex = 0;
+    let endIndex = 0;
     for (let i = 0; i < start_times.length; i += 1) {
       // convert the start/end time to a pixel
       const nextPixels = (widths && widths[i]) || 0;
@@ -552,6 +555,7 @@ function geojsonToSpectro(
         const lowPixels = start - additivePixels;
         const lowTime = start_times[i] + lowPixels / timeToPixels;
         start_time = Math.round(lowTime);
+        startIndex = i;
       }
       if (
         end_time === -1 &&
@@ -562,17 +566,21 @@ function geojsonToSpectro(
         const highPixels = end - additivePixels;
         const highTime = start_times[i] + highPixels / timeToPixels;
         end_time = Math.round(highTime);
+        endIndex = i;
       }
       additivePixels += nextPixels;
+    }
+    if (startIndex !== endIndex) {
+      warn = true;
     }
     const heightScale = adjustedHeight / (spectroInfo.high_freq - spectroInfo.low_freq);
     const high_freq = Math.round(spectroInfo.high_freq - coords[1][1] / heightScale);
     const low_freq = Math.round(spectroInfo.high_freq - coords[3][1] / heightScale);
-    if (start_time === -1 || end_time === -1) {
+    if (warn) {
       // the time spreads across multiple pulses and isn't allowed;
       return {
         error:
-          "Start or End Time spread across pusles.  This is not allowed in compressed annotations",
+          "Start or End Time spread across pulses.  This is not allowed in compressed annotations",
         start_time,
         end_time,
         low_freq,

--- a/client/src/components/geoJS/geoJSUtils.ts
+++ b/client/src/components/geoJS/geoJSUtils.ts
@@ -1,6 +1,8 @@
 import { ref, Ref } from "vue";
 import geo from "geojs";
 
+const annotationSpreadAcrossPulsesWarning = 'Start or End Time spread across pulses.  This is not allowed in compressed annotations';
+
 const useGeoJS = () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const geoViewer: Ref<any> = ref();
@@ -579,8 +581,7 @@ function geojsonToSpectro(
     if (warn) {
       // the time spreads across multiple pulses and isn't allowed;
       return {
-        warning:
-          "Start or End Time spread across pulses.  This is not allowed in compressed annotations",
+        warning: annotationSpreadAcrossPulsesWarning,
         start_time,
         end_time,
         low_freq,
@@ -674,4 +675,5 @@ export {
   textColorFromBackground,
   rectVertex,
   rectEdge,
+  annotationSpreadAcrossPulsesWarning,
 };

--- a/client/src/components/geoJS/layers/boundingBoxLayer.ts
+++ b/client/src/components/geoJS/layers/boundingBoxLayer.ts
@@ -3,7 +3,9 @@ import BaseTextLayer from "./baseTextLayer";
 import { geojsonToSpectro, SpectroInfo } from '../geoJSUtils';
 import { LayerStyle, RectGeoJSData, TextData } from './types';
 
-export default class BoundingBoxLayer extends BaseTextLayer<TextData> {
+type BoundingBoxTextData = TextData & { textAlign?: 'start' | 'end' | 'center', textBaseline?: 'top' | 'middle' | 'bottom' };
+
+export default class BoundingBoxLayer extends BaseTextLayer<BoundingBoxTextData> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   boxLayer: any;
   drawing: boolean;
@@ -24,9 +26,9 @@ export default class BoundingBoxLayer extends BaseTextLayer<TextData> {
     });
     this.textLayer = textLayer
       .createFeature('text')
-      .text((data: TextData) => data.text)
+      .text((data: BoundingBoxTextData) => data.text)
       .style(this.createTextStyle())
-      .position((data: TextData) => ({
+      .position((data: BoundingBoxTextData) => ({
         x: data.x,
         y: data.y,
       }));
@@ -98,45 +100,43 @@ export default class BoundingBoxLayer extends BaseTextLayer<TextData> {
 
     this.updateErrorState(warning);
 
-    const determineFreqOffset = (freq: number) => {
-      if (freq < 10000) return 38;
-      if (freq < 100000) return 40;
-      return 42;
-    };
-
     this.textData = [
       {
-        text: `${startTime}ms`,
+        text: `${startTime}ₘₛ`,
         x: coordinates[0][0],
-        y: coordinates[0][1],
+        y: coordinates[0][1] + 12,
+        textAlign: 'center',
+        textBaseline: 'top',
         offsetX: 0,
-        offsetY: 10,
+        offsetY: 0,
       },
       {
-        text: `${endTime}ms`,
+        text: `${endTime}ₘₛ`,
         x: coordinates[3][0],
-        y: coordinates[3][1],
-        offsetX: 0,
-        offsetY: 10,
+        y: coordinates[3][1] + 12,
+        textAlign: 'center',
+        textBaseline: 'top',
       },
       {
         text: `${(lowFreq / 1000).toFixed(1)}KHz`,
-        x: coordinates[3][0],
+        x: coordinates[3][0] + 5,
         y: coordinates[3][1],
-        offsetX: determineFreqOffset(lowFreq),
-        offsetY: -5,
+        textAlign: 'start',
+        textBaseline: 'middle',
       },
       {
         text: `${(highFreq / 1000).toFixed(1)}KHz`,
-        x: coordinates[2][0],
+        x: coordinates[2][0] + 5,
         y: coordinates[2][1],
-        offsetX: determineFreqOffset(highFreq),
-        offsetY: 5,
+        textAlign: 'start',
+        textBaseline: 'middle',
       },
       {
-        text: `${endTime - startTime}ms`,
+        text: `${endTime - startTime}ₘₛ`,
         x: (coordinates[0][0] + coordinates[2][0]) / 2,
         y: (coordinates[0][1] + coordinates[1][1]) / 2,
+        textAlign: 'center',
+        textBaseline: 'middle',
       },
     ];
     this.redraw();
@@ -204,15 +204,18 @@ export default class BoundingBoxLayer extends BaseTextLayer<TextData> {
     };
   }
 
-  createTextStyle(): LayerStyle<TextData> {
+  createTextStyle(): LayerStyle<BoundingBoxTextData> {
     return {
       fontSize: '16px',
+      textAlign: (data) => data.textAlign || 'start',
+      textBaseline: (data) => data.textBaseline || 'bottom',
       color: () => this.color,
       offset: (data) => ({
         x: data.offsetX || 0,
         y: data.offsetY || 0,
       }),
       textScaled: this.textScaled,
+
     };
   }
 

--- a/client/src/components/geoJS/layers/boundingBoxLayer.ts
+++ b/client/src/components/geoJS/layers/boundingBoxLayer.ts
@@ -32,7 +32,7 @@ export default class BoundingBoxLayer extends BaseTextLayer<TextData> {
       }));
 
       this.drawing = drawing || false;
-      this.boxError = null;
+      this.boxError = undefined;
 
       this.initialize();
   }
@@ -87,7 +87,7 @@ export default class BoundingBoxLayer extends BaseTextLayer<TextData> {
       end_time: endTime,
       low_freq: lowFreq,
       high_freq: highFreq,
-      error,
+      warning,
     } = geojsonToSpectro(
       geojsonData,
       this.spectroInfo,
@@ -95,7 +95,7 @@ export default class BoundingBoxLayer extends BaseTextLayer<TextData> {
       this.scaledHeight,
     );
 
-    this.updateErrorState(error);
+    this.updateErrorState(warning);
 
     const determineFreqOffset = (freq: number) => {
       if (freq < 10000) return 38;

--- a/client/src/components/geoJS/layers/boundingBoxLayer.ts
+++ b/client/src/components/geoJS/layers/boundingBoxLayer.ts
@@ -1,0 +1,216 @@
+import geo, { GeoEvent } from 'geojs';
+import BaseTextLayer from "./baseTextLayer";
+import { geojsonToSpectro, reOrdergeoJSON, SpectroInfo } from '../geoJSUtils';
+import { EditAnnotationTypes, LayerStyle, RectGeoJSData, TextData } from './types';
+
+export default class BoundingBoxLayer extends BaseTextLayer<TextData> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  boxLayer: any;
+  drawing: boolean;
+  _mode: 'editing' | 'creation' | null;
+
+  boxStyle: LayerStyle<RectGeoJSData>;
+
+  // formattedData: GeoJSON.Feature[];
+
+  disableModeSync: boolean;
+
+  selectedHandleIndex: number;
+  hoverHandleIndex: number;
+
+  shapeInProgress: GeoJSON.Polygon | GeoJSON.LineString | null;
+
+  constructor(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    geoViewerRef: any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    event: (name: string, data: any) => void,
+    spectroInfo: SpectroInfo,
+    drawing?: boolean,
+  ) {
+    super(geoViewerRef, event, spectroInfo);
+
+    const textLayer = this.geoViewerRef.createLayer('feature', {
+      features: ['text']
+    });
+    this.textLayer = textLayer
+      .createFeature('text')
+      .text((data: TextData) => data.text)
+      .style(this.createTextStyle())
+      .position((data: TextData) => ({
+        x: data.x,
+        y: data.y,
+      }));
+
+      this._mode = null;
+      this.drawing = drawing || false;
+
+      this.selectedHandleIndex = -1;
+      this.hoverHandleIndex = -1;
+      this.shapeInProgress = null;
+      this.disableModeSync = false;
+
+      this.initialize();
+  }
+
+  initialize() {
+    if (!this.boxLayer) {
+      this.boxLayer = this.geoViewerRef.createLayer('annotation', {
+        clickToEdit: true,
+        showLabels: false,
+        continuousPoiintProximity: false,
+        finalPointProximity: 1,
+        adjacentPointProximity: 1,
+      });
+    }
+    this.boxLayer.geoOn(geo.event.annotation.state, (e: GeoEvent) => this.handleAnnotationState(e));
+    this.boxLayer.geoOn(geo.event.annotation.edit_action, (e: GeoEvent) => this.handleAnnotationEditAction(e));
+  }
+
+  handleAnnotationState(e: GeoEvent) {
+    if (this.boxLayer !== e.annotation.layer()) {
+      // not an annotation owned by this object
+      return;
+    }
+    if (e.annotation.state() === 'done') {
+      this.event("update:cursor", { cursor: "default" });
+      this.updateLabels(e.annotation);
+      this.applyStyles();
+      this.redraw();
+    }
+  }
+
+  handleAnnotationEditAction(e: GeoEvent) {
+    if (this.boxLayer !== e.annotation.layer()) {
+      return;
+    }
+    if (e.annotation.state() === 'edit') {
+      this.updateLabels(e.annotation);
+    }
+  }
+
+  updateLabels(annotation: any) {
+    const geojsonData = annotation.geojson();
+    const coordinates = geojsonData.geometry.coordinates[0];
+    const {
+      start_time: startTime,
+      end_time: endTime,
+      low_freq: lowFreq,
+      high_freq: highFreq,
+    } = geojsonToSpectro(
+      geojsonData,
+      this.spectroInfo,
+      this.scaledWidth,
+      this.scaledHeight,
+    );
+
+    const determineFreqOffset = (freq: number) => {
+      if (freq < 10000) return 38;
+      if (freq < 100000) return 40;
+      return 42;
+    };
+
+    this.textData = [
+      {
+        text: `${startTime}ms`,
+        x: coordinates[0][0],
+        y: coordinates[0][1],
+        offsetX: 0,
+        offsetY: 10,
+      },
+      {
+        text: `${endTime}ms`,
+        x: coordinates[3][0],
+        y: coordinates[3][1],
+        offsetX: 0,
+        offsetY: 10,
+      },
+      {
+        text: `${lowFreq}KHz`,
+        x: coordinates[3][0],
+        y: coordinates[3][1],
+        offsetX: determineFreqOffset(lowFreq),
+        offsetY: -5,
+      },
+      {
+        text: `${highFreq}KHz`,
+        x: coordinates[2][0],
+        y: coordinates[2][1],
+        offsetX: determineFreqOffset(highFreq),
+        offsetY: 5,
+      },
+    ];
+    this.redraw();
+  }
+
+  enableDrawing() {
+    this.drawing = true;
+    this.event("update:cursor", { cursor: "mdi-vector-rectangle" });
+    if (this.boxLayer) {
+      this.boxLayer.mode('rectangle');
+    }
+  }
+
+  disableDrawing() {
+    this.drawing = false;
+    if (this.boxLayer) {
+      this.boxLayer.mode(null);
+      this.clearAnnotations();
+    }
+    if (this.textLayer) {
+      this.textData = [];
+      this.textLayer.data(this.textData).draw();
+    }
+  }
+
+  clearAnnotations() {
+    if (this.boxLayer) {
+      this.boxLayer.removeAllAnnotations();
+    }
+  }
+
+  redraw() {
+    if (this.textLayer) {
+      this.textLayer.data(this.textData).style(this.createTextStyle()).draw();
+    }
+    if (this.boxLayer) {
+      this.applyStyles();
+      this.boxLayer.draw();
+    }
+  }
+
+  applyStyles() {
+    if (this.boxLayer && this.boxLayer.annotations().length) {
+      this.boxLayer.annotations().forEach((annotation: { style: (style: LayerStyle<RectGeoJSData>) => void }) => {
+        annotation.style(this.createRectStyle());
+      });
+    }
+  }
+
+  _isDarkMode() {
+    return this.color === 'white';
+  }
+
+  createRectStyle(): LayerStyle<RectGeoJSData> {
+    return {
+      strokeWidth: 1.0,
+      antialiasing: 0,
+      stroke: true,
+      uniformPolygon: true,
+      fill: false,
+      strokeColor: this._isDarkMode() ? 'cyan' : 'magenta',
+    };
+  }
+
+  createTextStyle(): LayerStyle<TextData> {
+    return {
+      fontSize: '16px',
+      color: () => this._isDarkMode() ? 'yellow' : 'blue',
+      offset: (data) => ({
+        x: data.offsetX || 0,
+        y: data.offsetY || 0,
+      }),
+      textScaled: this.textScaled,
+    };
+  }
+}

--- a/client/src/components/geoJS/layers/boundingBoxLayer.ts
+++ b/client/src/components/geoJS/layers/boundingBoxLayer.ts
@@ -181,8 +181,9 @@ export default class BoundingBoxLayer extends BaseTextLayer<TextData> {
 
   applyStyles() {
     if (this.boxLayer && this.boxLayer.annotations().length) {
-      this.boxLayer.annotations().forEach((annotation: { style: (style: LayerStyle<RectGeoJSData>) => void }) => {
+      this.boxLayer.annotations().forEach((annotation: any) => {
         annotation.style(this.createRectStyle());
+        annotation.editHandleStyle(this.createEditHandleStyle());
       });
     }
   }
@@ -211,6 +212,16 @@ export default class BoundingBoxLayer extends BaseTextLayer<TextData> {
         y: data.offsetY || 0,
       }),
       textScaled: this.textScaled,
+    };
+  }
+
+  createEditHandleStyle() {
+    return {
+      handles: {
+        rotate: false,
+        resize: false,
+      },
+      strokeColor: this._isDarkMode() ? 'cyan' : 'magenta',
     };
   }
 }

--- a/client/src/components/geoJS/layers/boundingBoxLayer.ts
+++ b/client/src/components/geoJS/layers/boundingBoxLayer.ts
@@ -132,6 +132,11 @@ export default class BoundingBoxLayer extends BaseTextLayer<TextData> {
         offsetX: determineFreqOffset(highFreq),
         offsetY: 5,
       },
+      {
+        text: `${endTime - startTime}ms`,
+        x: (coordinates[0][0] + coordinates[2][0]) / 2,
+        y: (coordinates[0][1] + coordinates[1][1]) / 2,
+      },
     ];
     this.redraw();
   }
@@ -154,6 +159,7 @@ export default class BoundingBoxLayer extends BaseTextLayer<TextData> {
       this.textData = [];
       this.textLayer.data(this.textData).draw();
     }
+    this.updateErrorState(undefined);
   }
 
   clearAnnotations() {

--- a/client/src/components/geoJS/layers/boundingBoxLayer.ts
+++ b/client/src/components/geoJS/layers/boundingBoxLayer.ts
@@ -199,14 +199,14 @@ export default class BoundingBoxLayer extends BaseTextLayer<TextData> {
       stroke: true,
       uniformPolygon: true,
       fill: false,
-      strokeColor: this._isDarkMode() ? 'cyan' : 'magenta',
+      strokeColor: this._isDarkMode() ? 'yellow' : 'blue',
     };
   }
 
   createTextStyle(): LayerStyle<TextData> {
     return {
       fontSize: '16px',
-      color: () => this._isDarkMode() ? 'yellow' : 'blue',
+      color: () => this.color,
       offset: (data) => ({
         x: data.offsetX || 0,
         y: data.offsetY || 0,
@@ -221,7 +221,7 @@ export default class BoundingBoxLayer extends BaseTextLayer<TextData> {
         rotate: false,
         resize: false,
       },
-      strokeColor: this._isDarkMode() ? 'cyan' : 'magenta',
+      strokeColor: this._isDarkMode() ? 'yellow' : 'blue',
     };
   }
 }

--- a/client/src/components/geoJS/layers/boundingBoxLayer.ts
+++ b/client/src/components/geoJS/layers/boundingBoxLayer.ts
@@ -79,6 +79,7 @@ export default class BoundingBoxLayer extends BaseTextLayer<TextData> {
     this.event("bbox:error", { error: message });
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   updateLabels(annotation: any) {
     const geojsonData = annotation.geojson();
     const coordinates = geojsonData.geometry.coordinates[0];
@@ -180,6 +181,7 @@ export default class BoundingBoxLayer extends BaseTextLayer<TextData> {
 
   applyStyles() {
     if (this.boxLayer && this.boxLayer.annotations().length) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       this.boxLayer.annotations().forEach((annotation: any) => {
         annotation.style(this.createRectStyle());
         annotation.editHandleStyle(this.createEditHandleStyle());

--- a/client/src/components/geoJS/layers/editAnnotationLayer.ts
+++ b/client/src/components/geoJS/layers/editAnnotationLayer.ts
@@ -5,19 +5,11 @@ import {
   spectroToGeoJSon,
   reOrdergeoJSON,
   spectroSequenceToGeoJSon,
+  rectVertex,
+  rectEdge,
 } from "../geoJSUtils";
 import { SpectrogramAnnotation, SpectrogramSequenceAnnotation } from "../../../api/api";
-import { LayerStyle } from "./types";
-import { GeoJSON } from "geojson";
-
-export type EditAnnotationTypes = "rectangle";
-
-interface RectGeoJSData {
-  id: number;
-  selected: boolean;
-  editing: boolean | string;
-  polygon: GeoJSON.Polygon;
-}
+import { LayerStyle, RectGeoJSData, EditAnnotationTypes } from "./types";
 
 const typeMapper = new Map([
   ["LineString", "line"],
@@ -26,13 +18,6 @@ const typeMapper = new Map([
   ["rectangle", "rectangle"],
 ]);
 
-/**
- * correct matching of drag handle to cursor direction relies on strict ordering of
- * vertices within the GeoJSON coordinate list using utils.reOrdergeoJSON()
- * and utils.reOrderBounds()
- */
-const rectVertex = ["sw-resize", "nw-resize", "ne-resize", "se-resize"];
-const rectEdge = ["w-resize", "n-resize", "e-resize", "s-resize"];
 /**
  * This class is used to edit annotations within the viewer
  * It will do and display different things based on it either being in
@@ -416,7 +401,7 @@ export default class EditAnnotationLayer {
     }
     if (typeof this.type !== "string") {
       throw new Error(
-        `editing props needs to be a string of value 
+        `editing props needs to be a string of value
         ${geo.listAnnotations().join(", ")}
           when geojson prop is not set`
       );

--- a/client/src/components/geoJS/layers/editAnnotationLayer.ts
+++ b/client/src/components/geoJS/layers/editAnnotationLayer.ts
@@ -10,6 +10,7 @@ import {
 } from "../geoJSUtils";
 import { SpectrogramAnnotation, SpectrogramSequenceAnnotation } from "../../../api/api";
 import { LayerStyle, RectGeoJSData, EditAnnotationTypes } from "./types";
+import { GeoJSON } from 'geojson';
 
 const typeMapper = new Map([
   ["LineString", "line"],

--- a/client/src/components/geoJS/layers/types.ts
+++ b/client/src/components/geoJS/layers/types.ts
@@ -9,7 +9,7 @@ export interface LayerStyle<D> {
     strokeColor?: StyleFunction<string, D> | PointFunction<string, D>;
     fillColor?: StyleFunction<string, D> | PointFunction<string, D>;
     fillOpacity?: StyleFunction<number, D> | PointFunction<number, D>;
-    visible?: StyleFunction<boolean, D> | PointFunction<boolean, D>;
+    visible?: boolean | ((data: D) => boolean);
     position?: (point: [number, number]) => { x: number; y: number };
     color?: (data: D) => string;
     textOpacity?: (data: D) => number;
@@ -21,7 +21,6 @@ export interface LayerStyle<D> {
     textBaseline?: ((data: D) => string) | string;
     textScaled?: ((data: D) => number | undefined) | number | undefined;
     [x: string]: unknown;
-    visible?: (data: D) => boolean;
   }
 
 export type EditAnnotationTypes = "rectangle";

--- a/client/src/components/geoJS/layers/types.ts
+++ b/client/src/components/geoJS/layers/types.ts
@@ -24,6 +24,8 @@ export interface LayerStyle<D> {
     visible?: (data: D) => boolean;
   }
 
+export type EditAnnotationTypes = "rectangle";
+
 export interface RectGeoJSData {
   id: number;
   selected: boolean;

--- a/client/src/use/useState.ts
+++ b/client/src/use/useState.ts
@@ -66,6 +66,10 @@ const frequencyRulerY: Ref<number> = ref(0);
 const toggleMeasureMode = () => {
   measuring.value = !measuring.value;
 };
+const drawingBoundingBox = ref(false);
+const toggleDrawingBoundingBox = () => {
+  drawingBoundingBox.value = !drawingBoundingBox.value;
+};
 
 type AnnotationState = "" | "editing" | "creating" | "disabled";
 export default function useState() {
@@ -148,6 +152,8 @@ export default function useState() {
     measuring,
     toggleMeasureMode,
     frequencyRulerY,
+    drawingBoundingBox,
+    toggleDrawingBoundingBox,
     colorSchemes,
     colorScheme,
     backgroundColor,

--- a/client/src/use/useState.ts
+++ b/client/src/use/useState.ts
@@ -67,6 +67,7 @@ const toggleMeasureMode = () => {
   measuring.value = !measuring.value;
 };
 const drawingBoundingBox = ref(false);
+const boundingBoxError = ref('');
 const toggleDrawingBoundingBox = () => {
   drawingBoundingBox.value = !drawingBoundingBox.value;
 };
@@ -153,6 +154,7 @@ export default function useState() {
     toggleMeasureMode,
     frequencyRulerY,
     drawingBoundingBox,
+    boundingBoxError,
     toggleDrawingBoundingBox,
     colorSchemes,
     colorScheme,

--- a/client/src/views/NABat/NABatSpectrogram.vue
+++ b/client/src/views/NABat/NABatSpectrogram.vue
@@ -166,7 +166,15 @@ export default defineComponent({
       timeRef.value = time;
       freqRef.value = freq;
     };
-    watch(compressed, () => loadData());
+    watch(compressed, () => {
+      loadData();
+      if (drawingBoundingBox.value) {
+        toggleDrawingBoundingBox();
+      }
+      if (measuring.value) {
+        toggleMeasureMode();
+      }
+    });
 
 
     const toggleCompressedOverlay = () => {
@@ -184,6 +192,11 @@ export default defineComponent({
         });
       }
     }, { immediate: true });
+
+    const drawingBoxes = ref(false);
+    function toggleDrawingBoundingBoxes() {
+      drawingBoxes.value = !drawingBoxes.value;
+    }
 
     return {
       errorMessage,
@@ -208,7 +221,9 @@ export default defineComponent({
       viewCompressedOverlay,
       sideTab,
       measuring,
+      drawingBoxes,
       toggleMeasureMode,
+      toggleDrawingBoundingBoxes,
       // Color Scheme
       colorSchemes,
       colorScheme,
@@ -281,6 +296,20 @@ export default defineComponent({
               </div>
             </v-col>
             <v-spacer />
+            <v-tooltip>
+              <template #activator="{ props: subProps }">
+                <v-icon
+                  v-bind="subProps"
+                  size="35"
+                  class="mr-5 mt-5"
+                  :color="drawingBoxes ? 'blue' : ''"
+                  @click="toggleDrawingBoundingBoxes"
+                >
+                  mdi-border-radius
+                </v-icon>
+              </template>
+              <span>Draw bounding boxes to measure pulses</span>
+            </v-tooltip>
             <v-tooltip>
               <template #activator="{ props: subProps }">
                 <v-icon

--- a/client/src/views/NABat/NABatSpectrogram.vue
+++ b/client/src/views/NABat/NABatSpectrogram.vue
@@ -62,6 +62,8 @@ export default defineComponent({
       configuration,
       measuring,
       toggleMeasureMode,
+      drawingBoundingBox,
+      toggleDrawingBoundingBox,
     } = useState();
     const secondsWarning = 60;
     const { prompt } = usePrompt();
@@ -193,11 +195,6 @@ export default defineComponent({
       }
     }, { immediate: true });
 
-    const drawingBoxes = ref(false);
-    function toggleDrawingBoundingBoxes() {
-      drawingBoxes.value = !drawingBoxes.value;
-    }
-
     return {
       errorMessage,
       additionalErrors,
@@ -221,9 +218,9 @@ export default defineComponent({
       viewCompressedOverlay,
       sideTab,
       measuring,
-      drawingBoxes,
       toggleMeasureMode,
-      toggleDrawingBoundingBoxes,
+      drawingBoundingBox,
+      toggleDrawingBoundingBox,
       // Color Scheme
       colorSchemes,
       colorScheme,
@@ -302,8 +299,8 @@ export default defineComponent({
                   v-bind="subProps"
                   size="35"
                   class="mr-5 mt-5"
-                  :color="drawingBoxes ? 'blue' : ''"
-                  @click="toggleDrawingBoundingBoxes"
+                  :color="drawingBoundingBox ? 'blue' : ''"
+                  @click="toggleDrawingBoundingBox"
                 >
                   mdi-border-radius
                 </v-icon>

--- a/client/src/views/NABat/NABatSpectrogram.vue
+++ b/client/src/views/NABat/NABatSpectrogram.vue
@@ -173,9 +173,6 @@ export default defineComponent({
       if (drawingBoundingBox.value) {
         toggleDrawingBoundingBox();
       }
-      if (measuring.value) {
-        toggleMeasureMode();
-      }
     });
 
 

--- a/client/src/views/Spectrogram.vue
+++ b/client/src/views/Spectrogram.vue
@@ -66,6 +66,8 @@ export default defineComponent({
       configuration,
       measuring,
       toggleMeasureMode,
+      drawingBoundingBox,
+      toggleDrawingBoundingBox,
     } = useState();
     const images: Ref<HTMLImageElement[]> = ref([]);
     const spectroInfo: Ref<SpectroInfo | undefined> = ref();
@@ -242,6 +244,9 @@ export default defineComponent({
     };
     watch(compressed, () => {
       loadData();
+      if (drawingBoundingBox.value) {
+        toggleDrawingBoundingBox();
+      }
     });
 
     const keyboardEvent = (e: KeyboardEvent) => {
@@ -317,6 +322,8 @@ export default defineComponent({
       colorpickerMenu,
       measuring,
       toggleMeasureMode,
+      drawingBoundingBox,
+      toggleDrawingBoundingBox,
       // Other user selection
       otherUserAnnotations,
       sequenceAnnotations,
@@ -422,6 +429,21 @@ export default defineComponent({
                 </template>
               </v-select>
             </v-col>
+            <v-spacer />
+            <v-tooltip>
+              <template #activator="{ props: subProps }">
+                <v-icon
+                  v-bind="subProps"
+                  size="35"
+                  class="mr-5 mt-5"
+                  :color="drawingBoundingBox ? 'blue' : ''"
+                  @click="toggleDrawingBoundingBox"
+                >
+                  mdi-border-radius
+                </v-icon>
+              </template>
+              <span>Draw bounding boxes to measure pulses</span>
+            </v-tooltip>
             <v-spacer />
             <v-tooltip>
               <template #activator="{props: subProps }">

--- a/client/src/views/Spectrogram.vue
+++ b/client/src/views/Spectrogram.vue
@@ -242,9 +242,6 @@ export default defineComponent({
     };
     watch(compressed, () => {
       loadData();
-      if (measuring.value) {
-        toggleMeasureMode();
-      }
     });
 
     const keyboardEvent = (e: KeyboardEvent) => {

--- a/client/src/views/Spectrogram.vue
+++ b/client/src/views/Spectrogram.vue
@@ -66,6 +66,8 @@ export default defineComponent({
       configuration,
       measuring,
       toggleMeasureMode,
+      drawingBoundingBox,
+      toggleDrawingBoundingBox,
     } = useState();
     const images: Ref<HTMLImageElement[]> = ref([]);
     const spectroInfo: Ref<SpectroInfo | undefined> = ref();
@@ -292,11 +294,6 @@ export default defineComponent({
       viewCompressedOverlay.value = !viewCompressedOverlay.value;
     };
 
-    const drawingBoxes = ref(false);
-    function toggleDrawingBoundingBoxes() {
-      drawingBoxes.value = !drawingBoxes.value;
-    }
-
     return {
       annotationState,
       compressed,
@@ -328,8 +325,8 @@ export default defineComponent({
       colorpickerMenu,
       measuring,
       toggleMeasureMode,
-      drawingBoxes,
-      toggleDrawingBoundingBoxes,
+      drawingBoundingBox,
+      toggleDrawingBoundingBox,
       // Other user selection
       otherUserAnnotations,
       sequenceAnnotations,
@@ -442,8 +439,8 @@ export default defineComponent({
                   v-bind="subProps"
                   size="35"
                   class="mr-5 mt-5"
-                  :color="drawingBoxes ? 'blue' : ''"
-                  @click="toggleDrawingBoundingBoxes"
+                  :color="drawingBoundingBox ? 'blue' : ''"
+                  @click="toggleDrawingBoundingBox"
                 >
                   mdi-border-radius
                 </v-icon>

--- a/client/src/views/Spectrogram.vue
+++ b/client/src/views/Spectrogram.vue
@@ -67,6 +67,7 @@ export default defineComponent({
       measuring,
       toggleMeasureMode,
       drawingBoundingBox,
+      boundingBoxError,
       toggleDrawingBoundingBox,
     } = useState();
     const images: Ref<HTMLImageElement[]> = ref([]);
@@ -324,6 +325,7 @@ export default defineComponent({
       toggleMeasureMode,
       drawingBoundingBox,
       toggleDrawingBoundingBox,
+      boundingBoxError,
       // Other user selection
       otherUserAnnotations,
       sequenceAnnotations,
@@ -432,6 +434,13 @@ export default defineComponent({
             <v-spacer />
             <v-tooltip>
               <template #activator="{ props: subProps }">
+                <v-badge
+                  v-if="boundingBoxError"
+                  :offset-x="-37"
+                  :offset-y="-9"
+                  color="warning"
+                  dot
+                />
                 <v-icon
                   v-bind="subProps"
                   size="35"
@@ -442,9 +451,8 @@ export default defineComponent({
                   mdi-border-radius
                 </v-icon>
               </template>
-              <span>Draw bounding boxes to measure pulses</span>
+              <span>{{ boundingBoxError || 'Draw a bound box to measure pulses' }}</span>
             </v-tooltip>
-            <v-spacer />
             <v-tooltip>
               <template #activator="{props: subProps }">
                 <v-icon

--- a/client/src/views/Spectrogram.vue
+++ b/client/src/views/Spectrogram.vue
@@ -240,7 +240,15 @@ export default defineComponent({
       timeRef.value = time;
       freqRef.value = freq;
     };
-    watch(compressed, () => loadData());
+    watch(compressed, () => {
+      loadData();
+      if (drawingBoundingBox.value) {
+        toggleDrawingBoundingBox();
+      }
+      if (measuring.value) {
+        toggleMeasureMode();
+      }
+    });
 
     const keyboardEvent = (e: KeyboardEvent) => {
       if (e.key === "ArrowDown") {
@@ -284,6 +292,11 @@ export default defineComponent({
       viewCompressedOverlay.value = !viewCompressedOverlay.value;
     };
 
+    const drawingBoxes = ref(false);
+    function toggleDrawingBoundingBoxes() {
+      drawingBoxes.value = !drawingBoxes.value;
+    }
+
     return {
       annotationState,
       compressed,
@@ -315,6 +328,8 @@ export default defineComponent({
       colorpickerMenu,
       measuring,
       toggleMeasureMode,
+      drawingBoxes,
+      toggleDrawingBoundingBoxes,
       // Other user selection
       otherUserAnnotations,
       sequenceAnnotations,
@@ -421,6 +436,20 @@ export default defineComponent({
               </v-select>
             </v-col>
             <v-spacer />
+            <v-tooltip>
+              <template #activator="{ props: subProps }">
+                <v-icon
+                  v-bind="subProps"
+                  size="35"
+                  class="mr-5 mt-5"
+                  :color="drawingBoxes ? 'blue' : ''"
+                  @click="toggleDrawingBoundingBoxes"
+                >
+                  mdi-border-radius
+                </v-icon>
+              </template>
+              <span>Draw bounding boxes to measure pulses</span>
+            </v-tooltip>
             <v-tooltip>
               <template #activator="{props: subProps }">
                 <v-icon

--- a/client/src/views/Spectrogram.vue
+++ b/client/src/views/Spectrogram.vue
@@ -66,8 +66,6 @@ export default defineComponent({
       configuration,
       measuring,
       toggleMeasureMode,
-      drawingBoundingBox,
-      toggleDrawingBoundingBox,
     } = useState();
     const images: Ref<HTMLImageElement[]> = ref([]);
     const spectroInfo: Ref<SpectroInfo | undefined> = ref();
@@ -244,9 +242,6 @@ export default defineComponent({
     };
     watch(compressed, () => {
       loadData();
-      if (drawingBoundingBox.value) {
-        toggleDrawingBoundingBox();
-      }
       if (measuring.value) {
         toggleMeasureMode();
       }
@@ -325,8 +320,6 @@ export default defineComponent({
       colorpickerMenu,
       measuring,
       toggleMeasureMode,
-      drawingBoundingBox,
-      toggleDrawingBoundingBox,
       // Other user selection
       otherUserAnnotations,
       sequenceAnnotations,
@@ -433,20 +426,6 @@ export default defineComponent({
               </v-select>
             </v-col>
             <v-spacer />
-            <v-tooltip>
-              <template #activator="{ props: subProps }">
-                <v-icon
-                  v-bind="subProps"
-                  size="35"
-                  class="mr-5 mt-5"
-                  :color="drawingBoundingBox ? 'blue' : ''"
-                  @click="toggleDrawingBoundingBox"
-                >
-                  mdi-border-radius
-                </v-icon>
-              </template>
-              <span>Draw bounding boxes to measure pulses</span>
-            </v-tooltip>
             <v-tooltip>
               <template #activator="{props: subProps }">
                 <v-icon


### PR DESCRIPTION
Fix #201 

### Changes

Since the NABat spectrogram view has pulse level annotations disabled, there is no way to use the annotation tool to draw bounding boxes on the spectrogram to get rough time and frequency ranges for specific pulses in the image. 

This functionality is now replaced in the NABat spectrogram view by a bounding box tool. With the tool, users can draw a box on to the spectrogram. Once the box is drawn, the start time, end time, minimum frequency, and maximum frequency are all displayed as labels around the box.

Users can also click the box to enter "edit mode" and adjust the height and width of the box. As users edit the box, the labels will update to reflect the changes to the values reported.

## Video

https://github.com/user-attachments/assets/6bb8e4ec-a9fe-4198-8db2-38d6b31fe1be

In this video I demonstrate using the bounding box tool. Users click the icon next to the ruler to enable drawing a box. Once the box is drawn, it can be moved using the edit handles provided by GeoJS. The labels update as the user edits the annotation. If the user draws the box such that it spans multiple pulses on a compressed view, a badge will appear on the icon, and the tooltip will change to a message explaining that the user has done this.

@BryonLewis I tried replacing the `offset` by just using x/y values, but the behavior with `offset` seemed to work better here. Not sure how big of a deal that is.

TODO:
- [x] Add video and screenshots to this PR description 
- [x] Disable scaling/rotating the annotation