### PR TITLE
fix: adjust text alignment for measuring box

### DIFF
--- a/client/src/components/geoJS/layers/boundingBoxLayer.ts
+++ b/client/src/components/geoJS/layers/boundingBoxLayer.ts
@@ -3,7 +3,9 @@ import BaseTextLayer from "./baseTextLayer";
 import { geojsonToSpectro, SpectroInfo } from '../geoJSUtils';
 import { LayerStyle, RectGeoJSData, TextData } from './types';
 
-export default class BoundingBoxLayer extends BaseTextLayer<TextData> {
+type BoundingBoxTextData = TextData & { textAlign?: 'start' | 'end' | 'center', textBaseline?: 'top' | 'middle' | 'bottom' };
+
+export default class BoundingBoxLayer extends BaseTextLayer<BoundingBoxTextData> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   boxLayer: any;
   drawing: boolean;
@@ -24,9 +26,9 @@ export default class BoundingBoxLayer extends BaseTextLayer<TextData> {
     });
     this.textLayer = textLayer
       .createFeature('text')
-      .text((data: TextData) => data.text)
+      .text((data: BoundingBoxTextData) => data.text)
       .style(this.createTextStyle())
-      .position((data: TextData) => ({
+      .position((data: BoundingBoxTextData) => ({
         x: data.x,
         y: data.y,
       }));
@@ -98,45 +100,43 @@ export default class BoundingBoxLayer extends BaseTextLayer<TextData> {
 
     this.updateErrorState(warning);
 
-    const determineFreqOffset = (freq: number) => {
-      if (freq < 10000) return 38;
-      if (freq < 100000) return 40;
-      return 42;
-    };
-
     this.textData = [
       {
-        text: `${startTime}ms`,
+        text: `${startTime}ₘₛ`,
         x: coordinates[0][0],
-        y: coordinates[0][1],
+        y: coordinates[0][1] + 12,
+        textAlign: 'center',
+        textBaseline: 'top',
         offsetX: 0,
-        offsetY: 10,
+        offsetY: 0,
       },
       {
-        text: `${endTime}ms`,
+        text: `${endTime}ₘₛ`,
         x: coordinates[3][0],
-        y: coordinates[3][1],
-        offsetX: 0,
-        offsetY: 10,
+        y: coordinates[3][1] + 12,
+        textAlign: 'center',
+        textBaseline: 'top',
       },
       {
         text: `${(lowFreq / 1000).toFixed(1)}KHz`,
-        x: coordinates[3][0],
+        x: coordinates[3][0] + 5,
         y: coordinates[3][1],
-        offsetX: determineFreqOffset(lowFreq),
-        offsetY: -5,
+        textAlign: 'start',
+        textBaseline: 'middle',
       },
       {
         text: `${(highFreq / 1000).toFixed(1)}KHz`,
-        x: coordinates[2][0],
+        x: coordinates[2][0] + 5,
         y: coordinates[2][1],
-        offsetX: determineFreqOffset(highFreq),
-        offsetY: 5,
+        textAlign: 'start',
+        textBaseline: 'middle',
       },
       {
-        text: `${endTime - startTime}ms`,
+        text: `${endTime - startTime}ₘₛ`,
         x: (coordinates[0][0] + coordinates[2][0]) / 2,
         y: (coordinates[0][1] + coordinates[1][1]) / 2,
+        textAlign: 'center',
+        textBaseline: 'middle',
       },
     ];
     this.redraw();
@@ -204,15 +204,18 @@ export default class BoundingBoxLayer extends BaseTextLayer<TextData> {
     };
   }
 
-  createTextStyle(): LayerStyle<TextData> {
+  createTextStyle(): LayerStyle<BoundingBoxTextData> {
     return {
       fontSize: '16px',
+      textAlign: (data) => data.textAlign || 'start',
+      textBaseline: (data) => data.textBaseline || 'bottom',
       color: () => this.color,
       offset: (data) => ({
         x: data.offsetX || 0,
         y: data.offsetY || 0,
       }),
       textScaled: this.textScaled,
+
     };
   }
 

--- a/client/src/components/geoJS/layers/types.ts
+++ b/client/src/components/geoJS/layers/types.ts
@@ -9,7 +9,7 @@ export interface LayerStyle<D> {
     strokeColor?: StyleFunction<string, D> | PointFunction<string, D>;
     fillColor?: StyleFunction<string, D> | PointFunction<string, D>;
     fillOpacity?: StyleFunction<number, D> | PointFunction<number, D>;
-    visible?: StyleFunction<boolean, D> | PointFunction<boolean, D>;
+    visible?: boolean | ((data: D) => boolean);
     position?: (point: [number, number]) => { x: number; y: number };
     color?: (data: D) => string;
     textOpacity?: (data: D) => number;
@@ -21,7 +21,6 @@ export interface LayerStyle<D> {
     textBaseline?: ((data: D) => string) | string;
     textScaled?: ((data: D) => number | undefined) | number | undefined;
     [x: string]: unknown;
-    visible?: (data: D) => boolean;
   }
 
 export type EditAnnotationTypes = "rectangle";


### PR DESCRIPTION
Zooming out caused the text to move significantly when using the bounding box.

https://github.com/user-attachments/assets/aea5bdc2-fa33-45ef-a1ba-16052aef2c56

- Removes all `offsetX` and `offsetY` setting for values
- Updates the `TextData` with `BoundingBoxTextData` that includes `textAlign` and `textBaseline`
    - `textAlign` allows you to specify the start/end/center location for the X-axis of the text
    - `textBaseline` allows you to specify the top/middle/bottom for the Y-axis fo the text
- Using these I could get rid of `deteremineFreqOffset`
- I replaced all `ms` with `ₘₛ` the subscript version that is used else where in the annotation area.  It just reduces the size of text to hopefully make it easier if things are closer together.
- Also did a minor adjustment to the `types.ts`, I had an extra `visible` type declaration so I cleaned that up.