### PR TITLE
Update libgdal version for newer debian

### DIFF
--- a/dev/django.Dockerfile
+++ b/dev/django.Dockerfile
@@ -20,7 +20,7 @@ RUN set -ex \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         gcc \
         g++ \
-        libgdal32 \
+        libgdal36 \
         libc6-dev \
         libpq-dev \
         libsndfile1-dev \

--- a/prod/django.Dockerfile
+++ b/prod/django.Dockerfile
@@ -12,7 +12,7 @@ RUN set -ex \
         gcc \
         g++ \
         libc6-dev \
-        libgdal32 \
+        libgdal36 \
         libgdal-dev \
         libsndfile1-dev \
         ca-certificates \


### PR DESCRIPTION
Builds were failing because of libgdal32 not being found in the base uv:debian updated image.

Looked and underlying the OS release for ghcr.io/astral-sh/uv:debian is version 13-trixie, which supports libgdal36.
Of course we could massively increase build times and image sizes by using libgdal-de,v which will auto-install the correct one but I like not having a long build time.

The upgrade to the UV docker image notes can be found here:
https://github.com/astral-sh/uv/blob/148b694b6b1607042d4c267ae339e9ad93866499/CHANGELOG.md?plain=1#L196