### PR TITLE
Hide spectrogram controls in modals

### DIFF
--- a/client/src/components/ColorSchemeDialog.vue
+++ b/client/src/components/ColorSchemeDialog.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import { onMounted, watch } from 'vue';
+import useState from '@use/useState';
+import ColorSchemeSelect from './ColorSchemeSelect.vue';
+import ColorPickerMenu from './ColorPickerMenu.vue';
+
+const {
+  configuration,
+  colorSchemes,
+  colorScheme,
+  backgroundColor,
+} = useState();
+
+onMounted(() => {
+  const localBackgroundColor = localStorage.getItem('spectrogramBackgroundColor');
+  if (localBackgroundColor) {
+    backgroundColor.value = localBackgroundColor;
+  } else {
+    backgroundColor.value = configuration.value.default_spectrogram_background_color || 'rgb(0, 0, 0)';
+  }
+  const localColorScheme = localStorage.getItem('spectrogramColorScheme');
+  if (localColorScheme) {
+    colorScheme.value = colorSchemes.find((scheme) => scheme.value === localColorScheme) || colorSchemes[0];
+  } else if (configuration.value.default_color_scheme) {
+    colorScheme.value = colorSchemes.find((scheme) => scheme.value === configuration.value.default_color_scheme) || colorSchemes[0];
+  }
+});
+
+watch(backgroundColor, () => {
+  localStorage.setItem('spectrogramBackgroundColor', backgroundColor.value);
+});
+watch(colorScheme, () => {
+  localStorage.setItem('spectrogramColorScheme', colorScheme.value.value);
+});
+</script>
+
+<template>
+  <v-dialog max-width="300">
+    <template #activator="{ props: modalProps }">
+      <v-tooltip>
+        <template #activator="{ props: tooltipProps }">
+          <v-icon
+            v-bind="{ ...modalProps, ...tooltipProps }"
+            size="25"
+          >
+            mdi-palette
+          </v-icon>
+        </template>
+        View spectrogram color options
+      </v-tooltip>
+    </template>
+    <template #default="{ isActive }">
+      <v-card>
+        <v-card-title>
+          Spectrogram Color Options
+        </v-card-title>
+        <v-card-text>
+          <v-row>
+            <v-col cols="8">
+              <color-scheme-select
+                v-model="colorScheme"
+                label="Color Scheme"
+                :color-schemes="colorSchemes"
+                class="pt-3"
+              />
+            </v-col>
+            <v-col cols="4">
+              <color-picker-menu
+                v-model="backgroundColor"
+                tooltip-text="Spectrogram background color"
+              />
+            </v-col>
+          </v-row>
+        </v-card-text>
+        <v-card-actions>
+          <v-btn
+            text="Close"
+            @click="isActive.value = false"
+          />
+        </v-card-actions>
+      </v-card>
+    </template>
+  </v-dialog>
+</template>

--- a/client/src/components/OtherUserAnnotationsDialog.vue
+++ b/client/src/components/OtherUserAnnotationsDialog.vue
@@ -32,7 +32,6 @@ watch(selectedUsers, () => {
         <template #activator="{ props: tooltipProps }">
           <v-icon
             v-bind="{ ...modalProps, ...tooltipProps }"
-            class="mr-3 mt-3"
             size="25"
             :color="selectedUsers.length === 0 ? '' : 'blue'"
           >

--- a/client/src/views/Spectrogram.vue
+++ b/client/src/views/Spectrogram.vue
@@ -22,9 +22,8 @@ import { SpectroInfo } from "@components/geoJS/geoJSUtils";
 import AnnotationList from "@components/AnnotationList.vue";
 import ThumbnailViewer from "@components/ThumbnailViewer.vue";
 import RecordingList from "@components/RecordingList.vue";
-import ColorPickerMenu from "@components/ColorPickerMenu.vue";
-import ColorSchemeSelect from "@components/ColorSchemeSelect.vue";
 import OtherUserAnnotationsDialog from "@/components/OtherUserAnnotationsDialog.vue";
+import ColorSchemeDialog from "@/components/ColorSchemeDialog.vue";
 import useState from "@use/useState";
 import RecordingInfoDialog from "@components/RecordingInfoDialog.vue";
 export default defineComponent({
@@ -35,9 +34,8 @@ export default defineComponent({
     ThumbnailViewer,
     RecordingInfoDialog,
     RecordingList,
-    ColorPickerMenu,
-    ColorSchemeSelect,
     OtherUserAnnotationsDialog,
+    ColorSchemeDialog,
   },
   props: {
     id: {
@@ -214,27 +212,7 @@ export default defineComponent({
         loadData();
       }
     );
-    onMounted(() => {
-      loadData();
-      const localBackgroundColor = localStorage.getItem('spectrogramBackgroundColor');
-      if (localBackgroundColor) {
-        backgroundColor.value = localBackgroundColor;
-      } else {
-        backgroundColor.value = configuration.value.default_spectrogram_background_color || 'rgb(0, 0, 0)';
-      }
-      const localColorScheme = localStorage.getItem('spectrogramColorScheme');
-      if (localColorScheme) {
-        colorScheme.value = colorSchemes.find((scheme) => scheme.value === localColorScheme) || colorSchemes[0];
-      } else if (configuration.value.default_color_scheme) {
-        colorScheme.value = colorSchemes.find((scheme) => scheme.value === configuration.value.default_color_scheme) || colorSchemes[0];
-      }
-    });
-    watch(backgroundColor, () => {
-      localStorage.setItem('spectrogramBackgroundColor', backgroundColor.value);
-    });
-    watch(colorScheme, () => {
-      localStorage.setItem('spectrogramColorScheme', colorScheme.value.value);
-    });
+    onMounted(loadData);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const parentGeoViewerRef: Ref<any> = ref(null);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -405,13 +383,14 @@ export default defineComponent({
               color="primary"
               indeterminate
             />
-            <other-user-annotations-dialog
-              v-if="otherUsers.length && colorScale"
-              class="mr-3 mt-3"
-              :color-scale="colorScale"
-              :other-users="otherUsers"
-              :user-emails="Object.keys(otherUserAnnotations)"
-            />
+            <div class="mr-3 mt-3">
+              <other-user-annotations-dialog
+                v-if="otherUsers.length && colorScale"
+                :color-scale="colorScale"
+                :other-users="otherUsers"
+                :user-emails="Object.keys(otherUserAnnotations)"
+              />
+            </div>
             <v-tooltip>
               <template #activator="{ props: subProps }">
                 <v-icon
@@ -564,17 +543,8 @@ export default defineComponent({
               </template>
               <span> Highlight Compressed Areas</span>
             </v-tooltip>
-            <div class="color-scheme-flex">
-              <color-scheme-select
-                v-model="colorScheme"
-                label="Color Scheme"
-                :color-schemes="colorSchemes"
-                class="pt-3"
-              />
-              <color-picker-menu
-                v-model="backgroundColor"
-                tooltip-text="Spectrogram background color"
-              />
+            <div class="mt-4">
+              <color-scheme-dialog />
             </div>
           </v-row>
         </v-container>
@@ -671,16 +641,5 @@ export default defineComponent({
 <style scoped>
 .spectro-main {
   height: calc(100vh - 21vh - 64px - 72px);
-}
-
-.color-square {
-  width: 32px;
-  height: 32px;
-  min-width: 32px;
-  border-radius: 4px;
-}
-.color-scheme-flex {
-  display:flex;
-  align-items: center;
 }
 </style>


### PR DESCRIPTION
Fix #255 

Previously, on smaller screens or when the "Other Users" element was present, the spectrogram toolbar buttons would disappear as they wrapped to the next line.

One solution would be to change the CSS or layout of the toolbar to create a new row when this wrapping starts to happen. This could potentially start to eat up some valuable space used for displaying the spectrogram however.

This set of changes proposes to solve the problem in a slightly different way. Now, some of the bulkier (wider) controls that used to live in the toolbar have been moved to modals, which are activated by smaller icons from the toolbar.

While this does add extra clicks to some workflows, I believe that preserving space for the spectrogram is important. Additionally, the "Other Users" option appears only for specific scenarios, and that behavior might also be better suited for the annotation sidebar. The color scheme and background controls, which have also been moved to a modal here, save changes to local storage, so I think it's safe to assume user won't be constantly reopening this dialog.

Full sidebar with new icons:
<img width="1919" height="924" alt="image" src="https://github.com/user-attachments/assets/4929a2eb-6f11-457c-8161-e8d4f87c5756" />

"Other Users" dialog open:
<img width="1916" height="911" alt="image" src="https://github.com/user-attachments/assets/4b2d2fcf-ccbb-45e7-a6cf-d281cabceb0c" />

Color options dialog open:
<img width="1916" height="907" alt="image" src="https://github.com/user-attachments/assets/ac90415a-2b07-4166-bf78-8815af9a9749" />
