### PR TITLE
Make recordings default view for logged-in users

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -26,7 +26,7 @@ export default defineComponent({
         loginText.value = "Logout";
         loadConfiguration();
         if (sharedList.value.length === 0) {
-        getShared();
+          getShared();
         }
       } else {
         loginText.value = "Login";
@@ -85,12 +85,6 @@ export default defineComponent({
       >
         <v-tab
           to="/"
-          value="home"
-        >
-          Home
-        </v-tab>
-        <v-tab
-          to="/recordings"
           value="recordings"
         >
           Recordings
@@ -107,6 +101,12 @@ export default defineComponent({
           value="admin"
         >
           Admin
+        </v-tab>
+        <v-tab
+          to="/help"
+          value="help"
+        >
+          Help
         </v-tab>
       </v-tabs>
       <h3

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -1,5 +1,5 @@
 import { createRouter, createWebHistory, RouteLocationNormalized } from 'vue-router';
-import HomePage from '../views/HomePage.vue';
+import HelpPage from '../views/HelpPage.vue';
 import Recordings from '../views/Recordings.vue';
 import Spectrogram from '../views/Spectrogram.vue';
 import Login from '../views/Login.vue';
@@ -37,7 +37,7 @@ function routerInit(){
     routes: [
       {
         path: '/',
-        component: HomePage,
+        component: Recordings,
       },
       {
         path: '/login',
@@ -45,8 +45,8 @@ function routerInit(){
         component: Login,
       },
       {
-        path: '/recordings',
-        component: Recordings,
+        path: '/help',
+        component: HelpPage,
       },
       {
         path: '/admin',

--- a/client/src/views/HelpPage.vue
+++ b/client/src/views/HelpPage.vue
@@ -13,7 +13,7 @@ export default defineComponent({
 <template>
   <v-card>
     <v-card-title>
-      Bat-AI
+      BatAI Help
     </v-card-title>
     <v-card-text class="ma-5">
       <p>


### PR DESCRIPTION
Fix #261 

Change the existing "Home" tab into the "Recordings" tab, and create a new "Help" tab to house the content that used to exist under the "Home" tab.

Old:
<img width="1915" height="260" alt="image" src="https://github.com/user-attachments/assets/123e7e65-822a-4d15-b26b-e0da7451064c" />

New:
<img width="1913" height="226" alt="image" src="https://github.com/user-attachments/assets/5a6dc4fe-317b-4f8d-9786-02a5f75612c5" />
