### PR TITLE
Don't populate tag list with null tag

### DIFF
--- a/bats_ai/core/views/recording.py
+++ b/bats_ai/core/views/recording.py
@@ -252,13 +252,13 @@ def get_recordings(request: HttpRequest, public: bool | None = None):
         recordings = (
             Recording.objects.filter(public=True)
             .exclude(Q(owner=request.user) | Q(spectrogram__isnull=True))
-            .annotate(tags_text=ArrayAgg('tags__text'))
+            .annotate(tags_text=ArrayAgg('tags__text', filter=Q(tags__text__isnull=False)))
             .values()
         )
     else:
         recordings = (
             Recording.objects.filter(owner=request.user)
-            .annotate(tags_text=ArrayAgg('tags__text'))
+            .annotate(tags_text=ArrayAgg('tags__text', filter=Q(tags__text__isnull=False)))
             .values()
         )
 
@@ -298,7 +298,9 @@ def get_recording(request: HttpRequest, id: int):
     # Filter recordings based on the owner's id or public=True
     try:
         recordings = (
-            Recording.objects.filter(pk=id).annotate(tags_text=ArrayAgg('tags__text')).values()
+            Recording.objects.filter(pk=id)
+            .annotate(tags_text=ArrayAgg('tags__text', filter=Q(tags__text__isnull=False)))
+            .values()
         )
         if len(recordings) > 0:
             recording = recordings[0]


### PR DESCRIPTION
Previously, recordings with no tags would show up like this in the recordings view:
<img width="1076" height="349" alt="image" src="https://github.com/user-attachments/assets/b4f06854-2e4e-4021-a071-eeaa56e30b08" />


Now, we properly display tag-less recordings:
<img width="1138" height="356" alt="image" src="https://github.com/user-attachments/assets/aa3d2194-904a-445d-9edd-2ca631c824c2" />
