### PR TITLE
Allow Cloudflare Pages branch previews to have API access via CORS

### DIFF
--- a/terraform/django.tf
+++ b/terraform/django.tf
@@ -21,6 +21,10 @@ module "django" {
     # Can't make this use "aws_route53_record.www.fqdn" because of a circular dependency
     "https://www.${data.aws_route53_zone.this.name}",
   ]
+  django_cors_allowed_origin_regexes = [
+    # Can't base this on "cloudflare_pages_project.www.subdomain" because of a circular dependency
+    "https://[\\w-]+\\.bats-ai\\.pages\\.dev",
+  ]
   additional_django_vars = {
     DJANGO_SENTRY_DSN = "https://5bfdd2a77e7e8cbcea9ea873dbf9cbd6@o267860.ingest.us.sentry.io/4510800443015168"
   }


### PR DESCRIPTION
Need to follow the docs at: https://django-oauth-toolkit.readthedocs.io/en/latest/settings.html#allow-uri-wildcards

In short, update the OAuth2 `Application` to add `https://*.bats-ai.pages.dev/` to the allowed redirect URIs.