### PR TITLE
Limit heroku concurrency to 1

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -2,4 +2,4 @@ release: python ./manage.py migrate
 # Set `graceful_timeout` to shorter than the 30 second limit imposed by Heroku restarts
 # Set `timeout` to shorter than the 30 second limit imposed by the Heroku router
 web: gunicorn --bind 0.0.0.0:$PORT --graceful-timeout 25 --timeout 15 bats_ai.wsgi
-worker: REMAP_SIGTERM=SIGQUIT celery --app bats_ai.celery worker --loglevel INFO --without-heartbeat
+worker: REMAP_SIGTERM=SIGQUIT celery --app bats_ai.celery worker --loglevel INFO --without-heartbeat --concurrency 1


### PR DESCRIPTION
Due to high memory usage of spectrogram generation compared to the allowance on Heroku, limit the number of concurrent tasks that can be run to 1.