### PR TITLE
Load configuration after confirming login status

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -33,6 +33,7 @@ export default defineComponent({
     const checkLogin = async () => {
       if (oauthClient.isLoggedIn) {
         loginText.value = "Logout";
+        await loadConfiguration();
         await loadCurrentUser();
         await loadReviewerMaterials();
         if (sharedList.value.length === 0) {
@@ -53,7 +54,6 @@ export default defineComponent({
       }
     };
     onMounted(async () => {
-      await loadConfiguration();
       checkLogin();
     });
     router.afterEach((guard) => {


### PR DESCRIPTION
Previously on page load, if the user was logged in, we'd try to load the configuration, resulting in a `401` response from the server. 