### PR TITLE
install task dependecies for celery container

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -31,7 +31,6 @@ services:
       dockerfile: ./dev/django.Dockerfile
     command: [
       "uv", "run",
-      "--extra" ,"tasks",
       "celery",
       "--app", "bats_ai.celery",
       "worker",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,8 +67,8 @@ tasks = [
 dev = [
   # Additional developer tools
   # The "dev" dependency group is installed by default,
-  # so use this to install "development" extras by default too
-  "bats-ai[development]",
+  # so use this to install "development" and "tasks" extras by default too
+  "bats-ai[development, tasks]",
   "tox",
   "tox-uv",
 ]


### PR DESCRIPTION
- ~~Modified the command to install the optional `tasks` dependencies for the celery container.~~
- ~~Added a `uv_tasks_cache` for subsequent launches.~~ - save the cache volume between containers

Uses the fact that UV installs the dev dependency group if `--no-dev` isn't specified and adds `tasks` to that to 
