### PR TITLE
Reference materials rule fix

### DIFF
--- a/client/src/api/api.ts
+++ b/client/src/api/api.ts
@@ -634,10 +634,10 @@ async function getVettingDetailsForUser(userId: number) {
 }
 
 async function createOrUpdateVettingDetailsForUser(userId: number, referenceMaterials: string) {
-  return await axiosInstance.post<UpdateVettingDetails, VettingDetails>(
+  return (await axiosInstance.post<VettingDetails>(
     `/vetting/user/${userId}`,
     { 'reference_materials': referenceMaterials }
-  );
+  )).data;
 }
 
 export interface Contour {


### PR DESCRIPTION
I saw the following console error reported on sentry:

`TypeError: Cannot read properties of undefined (reading 'length')`

Sentry indicated that this was the result of the rule for checking max length of reviewer materials. Sometimes the rule function would run but the value would be undefined, so checking `v.length` would cause this error.

In this PR I changed the rule to prevent undefined values from causing this error.

I also noticed that reviewer materials was clunky, so I modified how reviewer materials are loaded by the system. Now the dialog component is responsible for loading them, and indicating to the user that loading is happening. (This is visible if you open the dialog before they are fully loaded, and when you click "Save."). Both saving and editing are now disabled while loading is happening.