### PR TITLE
Don't load reviewer materals on application start

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -21,7 +21,6 @@ export default defineComponent({
       loadConfiguration,
       configuration ,
       loadCurrentUser,
-      loadReviewerMaterials,
       loadFilterTags,
     } = useState();
     const getShared = async () => {
@@ -38,7 +37,6 @@ export default defineComponent({
         try {
           await loadConfiguration();
           await loadCurrentUser();
-          await loadReviewerMaterials();
           if (sharedList.value.length === 0) {
             getShared();
           }


### PR DESCRIPTION
This commit was supposed to be a part of #367, but didn't make it in time.

This finishes moving the responsibility of loading reviewer materials from the application root (App.vue) to the appropriate component.