### PR TITLE
swap mark_safe references to format_html

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,6 @@ repos:
       - id: debug-statements
       - id: destroyed-symlinks
       - id: detect-private-key
-      - id: double-quote-string-fixer
       - id: end-of-file-fixer
       - id: mixed-line-ending
         args: ['--fix=lf']

--- a/bats_ai/core/admin/recording.py
+++ b/bats_ai/core/admin/recording.py
@@ -4,7 +4,7 @@ from django.contrib import admin, messages
 from django.db.models import QuerySet
 from django.http import HttpRequest
 from django.urls import reverse
-from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 
 from bats_ai.core.models import Recording
 from bats_ai.core.tasks.tasks import recording_compute_spectrogram
@@ -58,8 +58,8 @@ class RecordingAdmin(admin.ModelAdmin):
         if recording.has_spectrogram:
             spectrogram = recording.spectrogram
             href = reverse("admin:core_spectrogram_change", args=(spectrogram.pk,))
-            description = str(spectrogram)
-            return mark_safe(f'<a href="{href}">{description}</a>')
+            spectrogram_obj_id_str = str(spectrogram)
+            return format_html('<a href="{}">{}</a>', href, spectrogram_obj_id_str)
         return None
 
     @admin.display(
@@ -70,8 +70,8 @@ class RecordingAdmin(admin.ModelAdmin):
         if recording.has_compressed_spectrogram:
             spectrogram = recording.compressed_spectrogram
             href = reverse("admin:core_compressedspectrogram_change", args=(spectrogram.pk,))
-            description = str(spectrogram)
-            return mark_safe(f'<a href="{href}">{description}</a>')
+            spectrogram_obj_id_str = str(spectrogram)
+            return format_html('<a href="{}">{}</a>', href, spectrogram_obj_id_str)
         return None
 
     @admin.action(description="Compute Spectrograms")


### PR DESCRIPTION
Was using mark_safe for a reverse lookup link in the django admin interface for spectrogram and compressed spectrogram references.
Swapped that to be `format_html` to make it safer.
Also updated the description references to be more representative of `spectrogram_obj_id_str`, indicating thatit  is a string that is used to reference the spectrogram Id and not a description.