### PR TITLE
disable heel rendering, new slope labels

### DIFF
--- a/client/src/components/PulseMetadataTooltip.vue
+++ b/client/src/components/PulseMetadataTooltip.vue
@@ -77,11 +77,11 @@ export default defineComponent({
             <span class="text-caption text-medium-emphasis mr-2">Knee</span>
             <span>{{ data.kneeKhz.toFixed(1) }} kHz</span>
           </div>
-          <div v-if="data.slopeAtHiFcKneeKhzPerMs != null"> 
+          <div v-if="data.slopeHiAvg != null"> 
             <span
               class="text-caption ml-4 text-medium-emphasis"
             >
-              ({{ data.slopeAtHiFcKneeKhzPerMs.toFixed(2) }} kHz/ms)
+              <b>Slope Hi Avg:</b> {{ data.slopeHiAvg.toFixed(2) }} kHz/ms
             </span>
           </div>
           <div
@@ -96,14 +96,15 @@ export default defineComponent({
             <span class="text-caption text-medium-emphasis mr-2">Fc</span>
             <span>{{ data.fcKhz.toFixed(1) }} kHz</span>
           </div>
-          <div v-if="data.slopeAtFcKhzPerMs != null"> 
+          <div v-if="data.slopeTotalAvg != null"> 
             <span
               class="text-caption ml-4 text-medium-emphasis"
             >
-              ({{ data.slopeAtFcKhzPerMs.toFixed(2) }} kHz/ms)
+              <b>Slope Total Avg:</b>{{ data.slopeTotalAvg.toFixed(2) }} kHz/ms
             </span>
           </div>
-          <div
+          <!-- DISABLED HEEL FOR NOW -->
+          <!-- <div
             v-if="data.heelKhz != null"
             class="d-flex align-center"
           >
@@ -114,14 +115,7 @@ export default defineComponent({
             />
             <span class="text-caption text-medium-emphasis mr-2">Heel</span>
             <span>{{ data.heelKhz.toFixed(1) }} kHz</span>
-          </div>
-          <div v-if="data.slopeAtLowFcHeelKhzPerMs != null"> 
-            <span
-              class="text-caption ml-4 text-medium-emphasis"
-            >
-              ({{ data.slopeAtLowFcHeelKhzPerMs.toFixed(2) }} kHz/ms)
-            </span>
-          </div>
+          </div> -->
           <div class="d-flex align-center">
             <span class="text-caption text-medium-emphasis mr-2">Duration</span>
             <span>{{ data.durationMs.toFixed(1) }} ms</span>

--- a/client/src/components/geoJS/layers/pulseMetadataLayer.ts
+++ b/client/src/components/geoJS/layers/pulseMetadataLayer.ts
@@ -41,12 +41,10 @@ export interface PulseMetadataTooltipData {
   charFreqColor: string | null;
   heelKhz: number | null;
   kneeKhz: number | null;
-  /** Slope at hi fc:knee (kHz/ms). */
-  slopeAtHiFcKneeKhzPerMs: number | null;
-  /** Slope at fc (kHz/ms). */
-  slopeAtFcKhzPerMs: number | null;
-  /** Slope at low fc:heel (kHz/ms). */
-  slopeAtLowFcHeelKhzPerMs: number | null;
+  /** Slope at Hi Avg. */
+  slopeHiAvg: number | null;
+  /** Slope at Total Avg. */
+  slopeTotalAvg: number | null;
   bbox: { top: number; left: number; width: number; height: number };
 }
 
@@ -62,6 +60,8 @@ const defaultPulseMetadataStyle: PulseMetadataStyle = {
   pointRadius: 5,
   pulseMetadataLabels: 'None',
 };
+
+const DISABLE_HEEL = true;
 
 export default class PulseMetadataLayer extends BaseTextLayer<TextData> {
   pulseMetadataList: PulseMetadata[];
@@ -291,9 +291,8 @@ export default class PulseMetadataLayer extends BaseTextLayer<TextData> {
       heelKhz: pulse.heel ? pulse.heel[1] / 1000 : null,
       kneeKhz: pulse.knee ? pulse.knee[1] / 1000 : null,
       charFreqColor: pulse.char_freq ? charFreqColor : null,
-      slopeAtHiFcKneeKhzPerMs: slopes?.slope_at_hi_fc_knee_khz_per_ms ?? null,
-      slopeAtFcKhzPerMs: slopes?.slope_at_fc_khz_per_ms ?? null,
-      slopeAtLowFcHeelKhzPerMs: slopes?.slope_at_low_fc_heel_khz_per_ms ?? null,
+      slopeHiAvg: slopes?.slope_hi_avg_khz_per_ms ?? null,
+      slopeTotalAvg: slopes?.slope_avg_khz_per_ms ?? null,
       bbox: { top: 0, left, width, height },
     };
   }
@@ -401,7 +400,7 @@ export default class PulseMetadataLayer extends BaseTextLayer<TextData> {
           textAlign: 'end',
         });
       }
-      if (pulse.heel && pulse.heel.length >= 2) {
+      if (!DISABLE_HEEL && pulse.heel && pulse.heel.length >= 2) {
         const pos = this.getCompressedPosition(pulse.heel[0], pulse.heel[1], index);
         this.pointData.push({ x: pos.x, y: pos.y, label: 'heel' });
         bboxPoints.push(pos);


### PR DESCRIPTION
Per some discussions with USGS about the demo:
- Remove the Heel Rendering
- Slope Hi Avg measurement
- Slope Total Avg measurement