### PR TITLE
Remove Django-Ninja workaround

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -39,9 +39,6 @@ commands =
     mypy {posargs}
 
 [testenv:test]
-setenv =
-    # Workaround until release of https://github.com/vitalik/django-ninja/pull/1622
-    NINJA_SKIP_REGISTRY = true
 dependency_groups =
     test
 commands =


### PR DESCRIPTION
No longer needed, now that we're using 1.6.0.