### PR TITLE
move ninja upload file out of import

### DIFF
--- a/bats_ai/core/views/guanometadata.py
+++ b/bats_ai/core/views/guanometadata.py
@@ -5,7 +5,9 @@ from typing import TYPE_CHECKING
 
 from django.http import HttpRequest, JsonResponse
 from ninja import File, Schema
-from ninja.files import UploadedFile
+
+# Django-Ninja accesses additional params directly, so we need to ignore the type checker.
+from ninja.files import UploadedFile  # noqa: TC002
 from ninja.pagination import RouterPaginated
 
 from bats_ai.core.utils.guano_utils import extract_guano_metadata

--- a/bats_ai/core/views/recording.py
+++ b/bats_ai/core/views/recording.py
@@ -11,7 +11,9 @@ from django.contrib.postgres.aggregates import ArrayAgg
 from django.core.files.storage import default_storage
 from django.db.models import Count, Exists, OuterRef, Prefetch, Q, QuerySet
 from ninja import File, Form, Query, Schema
-from ninja.files import UploadedFile
+
+# Django-Ninja accesses additional params directly, so we need to ignore the type checker.
+from ninja.files import UploadedFile  # noqa: TC002
 from ninja.pagination import RouterPaginated
 
 from bats_ai.core.models import (


### PR DESCRIPTION
Uploading WAV files to the interface failed.
This was caused by the Django ninja accessing the type of the parameter, which was  `import UploadedFile from ninja.files`.

Django-Ninja seems to access the type definition during runtime when used as a parameter for an endpoint:

https://github.com/vitalik/django-ninja/blob/56e868754e4ede8a47beb1833c8f67d4134339ea/ninja/signature/details.py#L221


https://github.com/vitalik/django-ninja/blob/56e868754e4ede8a47beb1833c8f67d4134339ea/ninja/signature/details.py#L57-L86

Here you can see that if you don't include the type annotation for HTTPRequest and your first parameter isn't named 'request', you can run into the same error.