### PR TITLE
override resonant default for account_get to resolve safelinks issue

### DIFF
--- a/bats_ai/settings/base.py
+++ b/bats_ai/settings/base.py
@@ -109,6 +109,10 @@ STATIC_URL = "static/"
 LOGIN_REDIRECT_URL = "/"
 ACCOUNT_LOGOUT_REDIRECT_URL = "/"
 
+# Override resonant_settings.allauth defaults
+# Prevents safelinks from breaking email confirmation by using a GET request
+ACCOUNT_CONFIRM_EMAIL_ON_GET = False
+
 CORS_ALLOWED_ORIGINS: list[str] = env.list("DJANGO_CORS_ALLOWED_ORIGINS", cast=str, default=[])
 CORS_ALLOWED_ORIGIN_REGEXES: list[str] = env.list(
     "DJANGO_CORS_ALLOWED_ORIGIN_REGEXES", cast=str, default=[]


### PR DESCRIPTION
Regarding users at some institutions having issues with the django-allauth  email verification link:

I'm wondering if Safelinks are pre-GETing the verification email link, so when a user opens it in their email, it is already verified and 'expired' because of this setting: https://github.com/kitware-resonant/cookiecutter-resonant/blob/master/django-resonant-settings/resonant_settings/allauth.py#L53 - ACCOUNT_CONFIRM_EMAIL_ON_GET=True

https://docs.allauth.org/en/latest/account/configuration.html#email-verification - documentation is just below this link.

I think when set to FALSE just adds an extra click to verification but should prevent Safelinks from triggering verification via GET before a user looks at the email.  The allauth documentation even mentions adding some JS to hit the POST endpoint automatically on the template so it behaves like a single click.