### PR TITLE
Only bind the Vite server to all interfaces in Docker

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -27,7 +27,6 @@ export default defineConfig({
     }),
   ],
   server: {
-    host: "0.0.0.0",
     port: 8080,
     proxy: {
       "/api": {

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -60,7 +60,7 @@ services:
     command: >
       sh -c "
         npm install &&
-        npm run dev
+        npm run dev -- --host 0.0.0.0
       "
     ports:
       - 8080:8080


### PR DESCRIPTION
This is a security risk when running on a native host.