### PR TITLE
update species api for backend changes

### DIFF
--- a/client/src/api/api.ts
+++ b/client/src/api/api.ts
@@ -39,6 +39,10 @@ export type RecordingLocationsFeatureProperties = {
 
 export type RecordingLocationsGeoJson = FeatureCollection<Point, RecordingLocationsFeatureProperties>;
 
+export interface SpeciesResponse {
+  items: Species[];
+  count: number;
+}
 export interface Species {
   species_code: string;
   family: string;
@@ -48,6 +52,7 @@ export interface Species {
   species?: string;
   id: number;
   category: "single" | "multiple" | "frequency" | "noid";
+  in_range?: boolean;
 }
 
 export interface SpectrogramAnnotation {
@@ -408,8 +413,8 @@ async function getSequenceAnnotations(recordingId: string) {
   );
 }
 
-async function getSpecies() {
-  return axiosInstance.get<Species[]>("/species/");
+async function getSpecies({recordingId, grtsCellId, sampleFrameId}: {recordingId?: number, grtsCellId?: number, sampleFrameId?: number}) {
+  return axiosInstance.get<SpeciesResponse>("/species/", { params: { recording_id: recordingId, grts_cell_id: grtsCellId, sample_frame_id: sampleFrameId } });
 }
 
 async function patchAnnotation(

--- a/client/src/views/NABat/NABatSpectrogram.vue
+++ b/client/src/views/NABat/NABatSpectrogram.vue
@@ -120,9 +120,9 @@ export default defineComponent({
         spectroInfo.value.end_times = response.data.compressed.end_times;
         viewCompressedOverlay.value = false;
       }
-      const speciesResponse = await getSpecies();
+      const speciesResponse = await getSpecies({ recordingId: parseInt(props.id) });
       // Removing NOISE species from list and any duplicates
-      speciesList.value = speciesResponse.data.filter(
+      speciesList.value = speciesResponse.data.items.filter(
         (value, index, self) => value.species_code !== "NOISE" && index === self.findIndex((t) => t.species_code === value.species_code)
       );
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/client/src/views/Spectrogram.vue
+++ b/client/src/views/Spectrogram.vue
@@ -228,9 +228,9 @@ export default defineComponent({
       if (spectrogramData.value.currentUser) {
         currentUser.value = spectrogramData.value.currentUser;
       }
-      const speciesResponse = await getSpecies();
+      const speciesResponse = await getSpecies({ recordingId: parseInt(props.id) });
       // Removing NOISE species from list and any duplicates
-      speciesList.value = speciesResponse.data .filter(
+      speciesList.value = speciesResponse.data.items.filter(
         (value, index, self) => index === self.findIndex((t) => t.species_code === value.species_code)
       );
       if (spectrogramData.value.otherUsers && spectroInfo.value) {


### PR DESCRIPTION
Resolves a sentry error that was occuring with the species-suggestion-backend.

Forgot that the structure of the species response had slightly changed that would cause issues with the format of the returned data.  Updated the response to fix the issue.