### PR TITLE
update species id references to species pk

### DIFF
--- a/client/src/api/api.ts
+++ b/client/src/api/api.ts
@@ -46,7 +46,7 @@ export interface Species {
   common_name: string;
   species_code_6?: string;
   species?: string;
-  id: number;
+  pk: number;
   category: "single" | "multiple" | "frequency" | "noid";
   in_range?: boolean;
 }

--- a/client/src/components/AnnotationEditor.vue
+++ b/client/src/components/AnnotationEditor.vue
@@ -59,7 +59,7 @@ export default defineComponent({
             speciesEdit.value.forEach((item) => {
                 const found = props.species.find((specie) => specie.species_code === item);
                 if (found) {
-                    speciesIds.push(found.id);
+                    speciesIds.push(found.pk);
                 }
             });
             const updateType = type.value.join('+');

--- a/client/src/components/RecordingAnnotationEditor.vue
+++ b/client/src/components/RecordingAnnotationEditor.vue
@@ -79,10 +79,12 @@ export default defineComponent({
             speciesEdit.value.forEach((item) => {
                 const found = props.species.find((specie) => specie.species_code === item);
                 if (found) {
-                  speciesIds.push(found.id);
+                  speciesIds.push(found.pk);
                 }
             });
-
+            console.log("speciesEdit", speciesEdit.value);
+            console.log("speciesIds", speciesIds);
+            console.log("props.species", props.species);
             const updateAnnotation: UpdateFileAnnotation & { apiToken?: string } = {
               recordingId: props.recordingId,
               comments: comments.value,

--- a/client/src/components/RecordingAnnotationEditor.vue
+++ b/client/src/components/RecordingAnnotationEditor.vue
@@ -82,9 +82,6 @@ export default defineComponent({
                   speciesIds.push(found.pk);
                 }
             });
-            console.log("speciesEdit", speciesEdit.value);
-            console.log("speciesIds", speciesIds);
-            console.log("props.species", props.species);
             const updateAnnotation: UpdateFileAnnotation & { apiToken?: string } = {
               recordingId: props.recordingId,
               comments: comments.value,

--- a/client/src/components/SpeciesNABatSave.vue
+++ b/client/src/components/SpeciesNABatSave.vue
@@ -137,7 +137,7 @@ export default defineComponent({
             <v-radio
               v-for="species in filteredSpecies"
               :key="species.species_code"
-              :value="species.id"
+              :value="species.pk"
               style="border: 1px solid black"
             >
               <template #label>


### PR DESCRIPTION
Fixes an issue where we removed the 'id' from the species return result  and are using `pk` instead of `id`.  The client didn't account for this change.