### PR TITLE
Fix N+1 queries with `RecordingAdmin` and remove `Recording` pathologic methods

### DIFF
--- a/bats_ai/core/admin/annotations.py
+++ b/bats_ai/core/admin/annotations.py
@@ -20,5 +20,5 @@ class AnnotationsAdmin(admin.ModelAdmin):
     ]
     list_select_related = True
     # list_select_related = ['owner']
-    filter_horizontal = ("species",)  # or filter_vertical
+    filter_horizontal = ["species"]  # or filter_vertical
     autocomplete_fields = ["owner"]

--- a/bats_ai/core/admin/configuration.py
+++ b/bats_ai/core/admin/configuration.py
@@ -7,13 +7,13 @@ from bats_ai.core.models.configuration import Configuration
 
 @admin.register(Configuration)
 class ConfigurationAdmin(admin.ModelAdmin):
-    list_display = (
+    list_display = [
         "display_pulse_annotations",
         "display_sequence_annotations",
         "run_inference_on_upload",
         "spectrogram_x_stretch",
         "spectrogram_view",
-    )
+    ]
 
     def has_add_permission(self, request):
         # Allow add only if there is no Configuration instance

--- a/bats_ai/core/admin/exported_annotation.py
+++ b/bats_ai/core/admin/exported_annotation.py
@@ -7,7 +7,7 @@ from bats_ai.core.models import ExportedAnnotationFile
 
 @admin.register(ExportedAnnotationFile)
 class ExportedAnnotationFileAdmin(admin.ModelAdmin):
-    list_display = (
+    list_display = [
         "id",
         "file",
         "download_url",
@@ -15,13 +15,13 @@ class ExportedAnnotationFileAdmin(admin.ModelAdmin):
         "expires_at",
         "created",
         "modified",
-    )
-    list_filter = ("status", "created", "modified", "expires_at")
-    search_fields = ("download_url", "file")
-    ordering = ("-created",)
-    readonly_fields = ("created", "modified")
+    ]
+    list_filter = ["status", "created", "modified", "expires_at"]
+    search_fields = ["download_url", "file"]
+    ordering = ["-created"]
+    readonly_fields = ["created", "modified"]
 
-    fieldsets = (
+    fieldsets = [
         (None, {"fields": ("file", "download_url", "status", "expires_at")}),
         (
             "Filters Applied",
@@ -36,4 +36,4 @@ class ExportedAnnotationFileAdmin(admin.ModelAdmin):
                 "fields": ("created", "modified"),
             },
         ),
-    )
+    ]

--- a/bats_ai/core/admin/grts_cells.py
+++ b/bats_ai/core/admin/grts_cells.py
@@ -7,9 +7,9 @@ from bats_ai.core.models import GRTSCells
 
 @admin.register(GRTSCells)
 class GRTSCellsAdmin(admin.ModelAdmin):
-    list_display = (
+    list_display = [
         "id",
         "grts_cell_id",
         "sample_frame_id",
-    )  # Add other fields you want to display in the list
-    search_fields = ("id", "grts_cell_id", "sample_frame_id")  # Add fields for searching
+    ]  # Add other fields you want to display in the list
+    search_fields = ["id", "grts_cell_id", "sample_frame_id"]  # Add fields for searching

--- a/bats_ai/core/admin/nabat/admin.py
+++ b/bats_ai/core/admin/nabat/admin.py
@@ -14,16 +14,16 @@ from bats_ai.core.models.nabat import (
 # Register models for the NaBat category
 @admin.register(NABatRecordingAnnotation)
 class NABatRecordingAnnotationAdmin(admin.ModelAdmin):
-    list_display = (
+    list_display = [
         "nabat_recording",
         "comments",
         "model",
         "confidence",
         "additional_data",
         "species_codes",
-    )
-    search_fields = ("nabat_recording_name", "comments", "model")
-    list_filter = ("nabat_recording",)
+    ]
+    search_fields = ["nabat_recording_name", "comments", "model"]
+    list_filter = ["nabat_recording"]
 
     @admin.display(description="Species Codes")
     def species_codes(self, obj):
@@ -33,7 +33,7 @@ class NABatRecordingAnnotationAdmin(admin.ModelAdmin):
 
 @admin.register(NABatSpectrogram)
 class NABatSpectrogramAdmin(admin.ModelAdmin):
-    list_display = (
+    list_display = [
         "nabat_recording",
         "width",
         "height",
@@ -41,9 +41,9 @@ class NABatSpectrogramAdmin(admin.ModelAdmin):
         "frequency_min",
         "frequency_max",
         "image_url_list_display",
-    )
-    search_fields = ("nabat_recording__name", "duration")
-    list_filter = ("nabat_recording", "duration")
+    ]
+    search_fields = ["nabat_recording__name", "duration"]
+    list_filter = ["nabat_recording", "duration"]
 
     @admin.display(description="Image URLs")
     def image_url_list_display(self, obj):
@@ -58,15 +58,15 @@ class NABatSpectrogramAdmin(admin.ModelAdmin):
 
 @admin.register(NABatCompressedSpectrogram)
 class NABatCompressedSpectrogramAdmin(admin.ModelAdmin):
-    list_display = (
+    list_display = [
         "nabat_recording",
         "spectrogram",
         "length",
         "cache_invalidated",
         "image_url_list_display",
-    )
-    search_fields = ("nabat_recording__name", "spectrogram__id")
-    list_filter = ("nabat_recording", "cache_invalidated")
+    ]
+    search_fields = ["nabat_recording__name", "spectrogram__id"]
+    list_filter = ["nabat_recording", "cache_invalidated"]
 
     @admin.display(description="Image URLs")
     def image_url_list_display(self, obj):
@@ -81,7 +81,7 @@ class NABatCompressedSpectrogramAdmin(admin.ModelAdmin):
 
 @admin.register(NABatRecording)
 class NABatRecordingAdmin(admin.ModelAdmin):
-    list_display = (
+    list_display = [
         "name",
         "recording_id",
         "equipment",
@@ -89,6 +89,6 @@ class NABatRecordingAdmin(admin.ModelAdmin):
         "recording_location",
         "grts_cell_id",
         "grts_cell",
-    )
-    search_fields = ("name", "recording_id", "recording_location")
-    list_filter = ("name", "recording_id", "recording_location")
+    ]
+    search_fields = ["name", "recording_id", "recording_location"]
+    list_filter = ["name", "recording_id", "recording_location"]

--- a/bats_ai/core/admin/processing_task.py
+++ b/bats_ai/core/admin/processing_task.py
@@ -7,12 +7,12 @@ from bats_ai.core.models import ProcessingTask
 
 @admin.register(ProcessingTask)
 class ProcessingTaskAdmin(admin.ModelAdmin):
-    list_display = ("id", "name", "status", "created", "modified", "celery_id", "metadata", "error")
-    list_filter = ("status", "created", "modified")
-    search_fields = ("name", "celery_id", "metadata", "error")
-    ordering = ("-created",)
-    readonly_fields = ("created", "modified")
-    fieldsets = (
+    list_display = ["id", "name", "status", "created", "modified", "celery_id", "metadata", "error"]
+    list_filter = ["status", "created", "modified"]
+    search_fields = ["name", "celery_id", "metadata", "error"]
+    ordering = ["-created"]
+    readonly_fields = ["created", "modified"]
+    fieldsets = [
         (None, {"fields": ("name", "status", "celery_id", "error")}),
         (
             "Metadata",
@@ -27,4 +27,4 @@ class ProcessingTaskAdmin(admin.ModelAdmin):
                 "fields": ("created", "modified"),
             },
         ),
-    )
+    ]

--- a/bats_ai/core/admin/pulse_metadata.py
+++ b/bats_ai/core/admin/pulse_metadata.py
@@ -7,7 +7,7 @@ from bats_ai.core.models import PulseMetadata
 
 @admin.register(PulseMetadata)
 class PulseMetadataAdmin(admin.ModelAdmin):
-    list_display = (
+    list_display = [
         "recording",
         "index",
         "bounding_box",
@@ -16,5 +16,5 @@ class PulseMetadataAdmin(admin.ModelAdmin):
         "knee",
         "heel",
         "slopes",
-    )
+    ]
     list_select_related = True

--- a/bats_ai/core/admin/recording.py
+++ b/bats_ai/core/admin/recording.py
@@ -7,7 +7,7 @@ from django.db.models import Prefetch
 from django.urls import reverse
 from django.utils.html import format_html
 
-from bats_ai.core.models import Recording, Spectrogram
+from bats_ai.core.models import CompressedSpectrogram, Recording, Spectrogram
 from bats_ai.core.tasks.tasks import recording_compute_spectrogram
 
 if TYPE_CHECKING:
@@ -58,7 +58,14 @@ class RecordingAdmin(admin.ModelAdmin):
                     "spectrograms",
                     # Ordering must be applied here, or else the prefetch cache won't be used
                     queryset=Spectrogram.objects.order_by("-created"),
-                )
+                ),
+                Prefetch(
+                    "compressed_spectrograms",
+                    # Exclude large ArrayField
+                    queryset=CompressedSpectrogram.objects.defer(
+                        "starts", "stops", "widths"
+                    ).order_by("-created"),
+                ),
             )
         )
 
@@ -88,11 +95,14 @@ class RecordingAdmin(admin.ModelAdmin):
         empty_value="Not computed",
     )
     def compressed_spectrogram_status(self, recording: Recording):
-        if recording.has_compressed_spectrogram:
-            spectrogram = recording.compressed_spectrogram
-            href = reverse("admin:core_compressedspectrogram_change", args=(spectrogram.pk,))
-            spectrogram_obj_id_str = str(spectrogram)
-            return format_html('<a href="{}">{}</a>', href, spectrogram_obj_id_str)
+        if recording.compressed_spectrograms.exists():
+            # Only this syntax will use the prefetch cache
+            compressed_spectrogram = recording.compressed_spectrograms.all()[0]
+            href = reverse(
+                "admin:core_compressedspectrogram_change", args=(compressed_spectrogram.pk,)
+            )
+            compressed_spectrogram_obj_id_str = str(compressed_spectrogram)
+            return format_html('<a href="{}">{}</a>', href, compressed_spectrogram_obj_id_str)
         return None
 
     @admin.action(description="Compute Spectrograms")

--- a/bats_ai/core/admin/recording.py
+++ b/bats_ai/core/admin/recording.py
@@ -40,8 +40,7 @@ class RecordingAdmin(admin.ModelAdmin):
         "get_computed_species",
         "get_official_species",
     ]
-    list_select_related = True
-    # list_select_related = ['owner']
+    list_select_related = ["owner"]
 
     search_fields = ["name"]
     actions = ["compute_spectrograms"]
@@ -66,16 +65,10 @@ class RecordingAdmin(admin.ModelAdmin):
                         "starts", "stops", "widths"
                     ).order_by("-created"),
                 ),
+                "official_species",
+                "computed_species",
             )
         )
-
-    @admin.display(description="Official Species")
-    def get_official_species(self, recording: Recording):
-        return [species.species_code_6 for species in recording.official_species.all()]
-
-    @admin.display(description="Computed Species")
-    def get_computed_species(self, recording: Recording):
-        return [species.species_code_6 for species in recording.computed_species.all()]
 
     @admin.display(
         description="Spectrogram",
@@ -104,6 +97,14 @@ class RecordingAdmin(admin.ModelAdmin):
             compressed_spectrogram_obj_id_str = str(compressed_spectrogram)
             return format_html('<a href="{}">{}</a>', href, compressed_spectrogram_obj_id_str)
         return None
+
+    @admin.display(description="Official Species")
+    def get_official_species(self, recording: Recording) -> list[str]:
+        return [species.species_code_6 for species in recording.official_species.all()]
+
+    @admin.display(description="Computed Species")
+    def get_computed_species(self, recording: Recording) -> list[str]:
+        return [species.species_code_6 for species in recording.computed_species.all()]
 
     @admin.action(description="Compute Spectrograms")
     def compute_spectrograms(self, request: HttpRequest, queryset: QuerySet):

--- a/bats_ai/core/admin/recording.py
+++ b/bats_ai/core/admin/recording.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from django.contrib import admin, messages
+from django.db.models import Prefetch
 from django.urls import reverse
 from django.utils.html import format_html
 
-from bats_ai.core.models import Recording
+from bats_ai.core.models import Recording, Spectrogram
 from bats_ai.core.tasks.tasks import recording_compute_spectrogram
 
 if TYPE_CHECKING:
@@ -48,19 +49,35 @@ class RecordingAdmin(admin.ModelAdmin):
     autocomplete_fields = ["owner"]
     readonly_fields = ["created", "modified"]
 
-    def get_official_species(self, instance):
-        return [species.species_code_6 for species in instance.official_species.all()]
+    def get_queryset(self, request):
+        return (
+            super()
+            .get_queryset(request)
+            .prefetch_related(
+                Prefetch(
+                    "spectrograms",
+                    # Ordering must be applied here, or else the prefetch cache won't be used
+                    queryset=Spectrogram.objects.order_by("-created"),
+                )
+            )
+        )
 
-    def get_computed_species(self, instance):
-        return [species.species_code_6 for species in instance.computed_species.all()]
+    @admin.display(description="Official Species")
+    def get_official_species(self, recording: Recording):
+        return [species.species_code_6 for species in recording.official_species.all()]
+
+    @admin.display(description="Computed Species")
+    def get_computed_species(self, recording: Recording):
+        return [species.species_code_6 for species in recording.computed_species.all()]
 
     @admin.display(
         description="Spectrogram",
         empty_value="Not computed",
     )
     def spectrogram_status(self, recording: Recording):
-        if recording.has_spectrogram:
-            spectrogram = recording.spectrogram
+        if recording.spectrograms.exists():
+            # Only this syntax will use the prefetch cache
+            spectrogram = recording.spectrograms.all()[0]
             href = reverse("admin:core_spectrogram_change", args=(spectrogram.pk,))
             spectrogram_obj_id_str = str(spectrogram)
             return format_html('<a href="{}">{}</a>', href, spectrogram_obj_id_str)

--- a/bats_ai/core/admin/recording_tag.py
+++ b/bats_ai/core/admin/recording_tag.py
@@ -8,20 +8,21 @@ from bats_ai.core.models import RecordingTag
 
 @admin.register(RecordingTag)
 class RecordingTagAdmin(admin.ModelAdmin):
-    list_display = (
+    list_display = [
         "id",
         "user",
         "text",
         "recording_count",
-    )
-    search_fields = ("id", "user", "text")
+    ]
+    search_fields = ["id", "user", "text"]
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
         return qs.annotate(_recording_count=Count("recording"))
 
+    @admin.display(
+        description="Number of recordings",
+        ordering="_recording_count",
+    )
     def recording_count(self, obj):
         return obj._recording_count
-
-    recording_count.short_description = "Number of recordings"
-    recording_count.admin_order_field = "_recording_count"

--- a/bats_ai/core/admin/vetting_details.py
+++ b/bats_ai/core/admin/vetting_details.py
@@ -12,4 +12,4 @@ class VettingDetailsAdmin(admin.ModelAdmin):
         "user",
         # 'reference_materials',
     ]
-    search_fields = ("user",)
+    search_fields = ["user"]

--- a/bats_ai/core/migrations/0037_alter_spectrogram_recording.py
+++ b/bats_ai/core/migrations/0037_alter_spectrogram_recording.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0036_rename_grts_cell_recording_sample_frame_id_and_more"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="nabatspectrogram",
+            name="nabat_recording",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="spectrograms",
+                to="core.nabatrecording",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="spectrogram",
+            name="recording",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="spectrograms",
+                to="core.recording",
+            ),
+        ),
+    ]

--- a/bats_ai/core/migrations/0038_alter_compressedspectrogram_recording.py
+++ b/bats_ai/core/migrations/0038_alter_compressedspectrogram_recording.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0037_alter_spectrogram_recording"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="compressedspectrogram",
+            name="recording",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="compressed_spectrograms",
+                to="core.recording",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="nabatcompressedspectrogram",
+            name="nabat_recording",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="compressed_spectrograms",
+                to="core.nabatrecording",
+            ),
+        ),
+    ]

--- a/bats_ai/core/migrations/0039_alter_species_options.py
+++ b/bats_ai/core/migrations/0039_alter_species_options.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0038_alter_compressedspectrogram_recording"),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name="species",
+            options={"verbose_name_plural": "species"},
+        ),
+    ]

--- a/bats_ai/core/models/compressed_spectrogram.py
+++ b/bats_ai/core/models/compressed_spectrogram.py
@@ -13,7 +13,9 @@ from .spectrogram_image import SpectrogramImage
 
 # TimeStampedModel also provides "created" and "modified" fields
 class CompressedSpectrogram(TimeStampedModel, models.Model):
-    recording = models.ForeignKey(Recording, on_delete=models.CASCADE)
+    recording = models.ForeignKey(
+        Recording, on_delete=models.CASCADE, related_name="compressed_spectrograms"
+    )
     spectrogram = models.ForeignKey(Spectrogram, on_delete=models.CASCADE)
     length = models.FloatField()
     images = GenericRelation(SpectrogramImage)

--- a/bats_ai/core/models/nabat/nabat_compressed_spectrogram.py
+++ b/bats_ai/core/models/nabat/nabat_compressed_spectrogram.py
@@ -14,7 +14,9 @@ from .nabat_spectrogram import NABatSpectrogram
 
 # TimeStampedModel also provides "created" and "modified" fields
 class NABatCompressedSpectrogram(TimeStampedModel, models.Model):
-    nabat_recording = models.ForeignKey(NABatRecording, on_delete=models.CASCADE)
+    nabat_recording = models.ForeignKey(
+        NABatRecording, on_delete=models.CASCADE, related_name="compressed_spectrograms"
+    )
     spectrogram = models.ForeignKey(NABatSpectrogram, on_delete=models.CASCADE)
     images = GenericRelation(SpectrogramImage)
     length = models.FloatField()

--- a/bats_ai/core/models/nabat/nabat_recording.py
+++ b/bats_ai/core/models/nabat/nabat_recording.py
@@ -45,21 +45,6 @@ class NABatRecording(TimeStampedModel, models.Model):
 
     unusual_occurrences = models.TextField(blank=True, null=True)
 
-    @property
-    def has_compressed_spectrogram(self):
-        return len(self.compressed_spectrograms) > 0
-
-    @property
-    def compressed_spectrograms(self):
-        from bats_ai.core.models.nabat import NABatCompressedSpectrogram
-
-        query = NABatCompressedSpectrogram.objects.filter(nabat_recording=self).order_by("-created")
-        return query.all()
-
-    @property
-    def compressed_spectrogram(self):
-        return self.compressed_spectrograms.latest("created")
-
     class Meta:
         verbose_name = "NABat Recording"
         verbose_name_plural = "NABat Recording"

--- a/bats_ai/core/models/nabat/nabat_recording.py
+++ b/bats_ai/core/models/nabat/nabat_recording.py
@@ -46,21 +46,6 @@ class NABatRecording(TimeStampedModel, models.Model):
     unusual_occurrences = models.TextField(blank=True, null=True)
 
     @property
-    def has_spectrogram(self):
-        return len(self.spectrograms) > 0
-
-    @property
-    def spectrograms(self):
-        from bats_ai.core.models.nabat import NABatSpectrogram
-
-        query = NABatSpectrogram.objects.filter(nabat_recording=self).order_by("-created")
-        return query.all()
-
-    @property
-    def spectrogram(self):
-        return self.spectrograms.latest("created")
-
-    @property
     def has_compressed_spectrogram(self):
         return len(self.compressed_spectrograms) > 0
 

--- a/bats_ai/core/models/nabat/nabat_spectrogram.py
+++ b/bats_ai/core/models/nabat/nabat_spectrogram.py
@@ -16,7 +16,9 @@ logger = logging.getLogger(__name__)
 
 # TimeStampedModel also provides "created" and "modified" fields
 class NABatSpectrogram(TimeStampedModel, models.Model):
-    nabat_recording = models.ForeignKey(NABatRecording, on_delete=models.CASCADE)
+    nabat_recording = models.ForeignKey(
+        NABatRecording, on_delete=models.CASCADE, related_name="spectrograms"
+    )
     images = GenericRelation(SpectrogramImage)
     width = models.IntegerField()  # pixels
     height = models.IntegerField()  # pixels

--- a/bats_ai/core/models/recording.py
+++ b/bats_ai/core/models/recording.py
@@ -51,21 +51,6 @@ class Recording(TimeStampedModel, models.Model):
     unusual_occurrences = models.TextField(blank=True, null=True)
     tags = models.ManyToManyField(RecordingTag)
 
-    @property
-    def has_compressed_spectrogram(self):
-        return len(self.compressed_spectrograms) > 0
-
-    @property
-    def compressed_spectrograms(self):
-        from bats_ai.core.models import CompressedSpectrogram
-
-        query = CompressedSpectrogram.objects.filter(recording=self).order_by("-created")
-        return query.all()
-
-    @property
-    def compressed_spectrogram(self):
-        return self.compressed_spectrograms.latest("created")
-
 
 @receiver(models.signals.pre_delete, sender=Recording)
 def delete_content(sender, instance, **kwargs):

--- a/bats_ai/core/models/recording.py
+++ b/bats_ai/core/models/recording.py
@@ -52,21 +52,6 @@ class Recording(TimeStampedModel, models.Model):
     tags = models.ManyToManyField(RecordingTag)
 
     @property
-    def has_spectrogram(self):
-        return len(self.spectrograms) > 0
-
-    @property
-    def spectrograms(self):
-        from bats_ai.core.models import Spectrogram
-
-        query = Spectrogram.objects.filter(recording=self).order_by("-created")
-        return query.all()
-
-    @property
-    def spectrogram(self):
-        return self.spectrograms.latest("created")
-
-    @property
     def has_compressed_spectrogram(self):
         return len(self.compressed_spectrograms) > 0
 

--- a/bats_ai/core/models/species.py
+++ b/bats_ai/core/models/species.py
@@ -24,5 +24,8 @@ class Species(models.Model):
         help_text="Category label: single species, multiple species, frequency, or NoID",
     )
 
+    class Meta:
+        verbose_name_plural = "species"
+
     def __str__(self) -> str:
         return self.species_code or str(self.pk)

--- a/bats_ai/core/models/spectrogram.py
+++ b/bats_ai/core/models/spectrogram.py
@@ -10,7 +10,7 @@ from .spectrogram_image import SpectrogramImage
 
 
 class Spectrogram(TimeStampedModel, models.Model):
-    recording = models.ForeignKey(Recording, on_delete=models.CASCADE)
+    recording = models.ForeignKey(Recording, on_delete=models.CASCADE, related_name="spectrograms")
     images = GenericRelation(SpectrogramImage)
     width = models.IntegerField()  # pixels
     height = models.IntegerField()  # pixels

--- a/bats_ai/core/views/nabat/nabat_recording.py
+++ b/bats_ai/core/views/nabat/nabat_recording.py
@@ -270,7 +270,7 @@ def get_spectrogram(request: HttpRequest, pk: int):
 
     spectrogram = nabat_recording.spectrograms.latest("created")
 
-    compressed = nabat_recording.compressed_spectrogram
+    compressed = nabat_recording.compressed_spectrograms.latest("created")
 
     spectro_data = {
         "urls": spectrogram.image_url_list,

--- a/bats_ai/core/views/nabat/nabat_recording.py
+++ b/bats_ai/core/views/nabat/nabat_recording.py
@@ -268,7 +268,7 @@ def generate_nabat_recording(
 def get_spectrogram(request: HttpRequest, pk: int):
     nabat_recording = get_object_or_404(NABatRecording, pk=pk)
 
-    spectrogram = nabat_recording.spectrogram
+    spectrogram = nabat_recording.spectrograms.latest("created")
 
     compressed = nabat_recording.compressed_spectrogram
 

--- a/bats_ai/core/views/recording.py
+++ b/bats_ai/core/views/recording.py
@@ -762,7 +762,7 @@ def get_spectrogram(request: HttpRequest, pk: int):
 
     spectrogram = recording.spectrograms.latest("created")
 
-    compressed = recording.compressed_spectrogram
+    compressed = recording.compressed_spectrograms.latest("created")
 
     spectro_data = {
         "urls": spectrogram.image_url_list,

--- a/bats_ai/core/views/recording.py
+++ b/bats_ai/core/views/recording.py
@@ -686,7 +686,9 @@ def get_recording(request: HttpRequest, pk: int):
             user = User.objects.get(id=recording["owner_id"])
             recording["owner_username"] = user.username
             recording["audio_file_presigned_url"] = default_storage.url(recording["audio_file"])
-            recording["hasSpectrogram"] = Recording.objects.get(id=recording["id"]).has_spectrogram
+            recording["hasSpectrogram"] = Recording.objects.get(
+                id=recording["id"]
+            ).spectrograms.exists()
             if recording["recording_location"]:
                 recording["recording_location"] = json.loads(recording["recording_location"].json)
             annotation_owners = (
@@ -758,7 +760,7 @@ def get_spectrogram(request: HttpRequest, pk: int):
     except Recording.DoesNotExist:
         return {"error": "Recording not found"}
 
-    spectrogram = recording.spectrogram
+    spectrogram = recording.spectrograms.latest("created")
 
     compressed = recording.compressed_spectrogram
 


### PR DESCRIPTION
See individual commits.

The reduces the number of queries to load a full `RecordingAdmin` page from 607 to 10.

Also makes the admin say "species" instead of "speciess". :upside_down_face: