### PR TITLE
Suggested species updates

### DIFF
--- a/bats_ai/core/fixtures/species.json
+++ b/bats_ai/core/fixtures/species.json
@@ -613,7 +613,7 @@
   {
     "fields": {
       "category": "single",
-      "common_name": "Arizona bat",
+      "common_name": "Arizona myotis",
       "family": "Vespertilionidae",
       "genus": "Myotis",
       "species": "Myotis occultus",
@@ -1121,7 +1121,7 @@
     "fields": {
       "category": "single",
       "common_name": "Keen's myotis",
-      "family": "",
+      "family": "Vespertilionidae",
       "genus": "Myotis",
       "species": "Myotis keenii",
       "species_code": "MYKE",
@@ -1623,31 +1623,5 @@
     },
     "model": "core.Species",
     "pk": "133"
-  },
-  {
-    "fields": {
-      "category": "single",
-      "common_name": "Arizona myotis",
-      "family": "Vespertilionidae",
-      "genus": "Myotis",
-      "species": "Myotis occultus",
-      "species_code": "MYOC",
-      "species_code_6": "MYOOCC"
-    },
-    "model": "core.Species",
-    "pk": 134
-  },
-  {
-    "fields": {
-      "category": "single",
-      "common_name": "Keen's myotis",
-      "family": "Vespertilionidae",
-      "genus": "Myotis",
-      "species": "Myotis keenii",
-      "species_code": "MYKE",
-      "species_code_6": "MYOKEE"
-    },
-    "model": "core.Species",
-    "pk": 135
   }
 ]

--- a/bats_ai/core/fixtures/species.json
+++ b/bats_ai/core/fixtures/species.json
@@ -148,9 +148,9 @@
       "common_name": "Western red bat",
       "family": "Vespertilionidae",
       "genus": "Lasiurus",
-      "species": "Lasiurus blossevillii",
-      "species_code": "LABL",
-      "species_code_6": "LASBLO"
+      "species": "Lasiurus frantzii",
+      "species_code": "LAFR",
+      "species_code_6": "LASFRA"
     },
     "model": "core.Species",
     "pk": "12"
@@ -1623,5 +1623,31 @@
     },
     "model": "core.Species",
     "pk": "133"
+  },
+  {
+    "fields": {
+      "category": "single",
+      "common_name": "Arizona myotis",
+      "family": "Vespertilionidae",
+      "genus": "Myotis",
+      "species": "Myotis occultus",
+      "species_code": "MYOC",
+      "species_code_6": "MYOOCC"
+    },
+    "model": "core.Species",
+    "pk": 134
+  },
+  {
+    "fields": {
+      "category": "single",
+      "common_name": "Keen's myotis",
+      "family": "Vespertilionidae",
+      "genus": "Myotis",
+      "species": "Myotis keenii",
+      "species_code": "MYKE",
+      "species_code_6": "MYOKEE"
+    },
+    "model": "core.Species",
+    "pk": 135
   }
 ]

--- a/bats_ai/core/fixtures/species.json
+++ b/bats_ai/core/fixtures/species.json
@@ -681,8 +681,8 @@
       "common_name": "Western red bat/Canyon bat",
       "family": "",
       "genus": "",
-      "species": "Lasiurus blossevillii/Parastrellus hesperus",
-      "species_code": "LABLPAHE",
+      "species": "Lasiurus frantzii/Parastrellus hesperus",
+      "species_code": "LAFRPAHE",
       "species_code_6": ""
     },
     "model": "core.Species",

--- a/client/src/components/SingleSpecieEditor.vue
+++ b/client/src/components/SingleSpecieEditor.vue
@@ -11,7 +11,7 @@ import {
 } from "vue";
 import type { Species } from "@api/api";
 import SingleSpecieInfo from "./SingleSpecieInfo.vue";
-const suggestedSpeciesKey = "suggested species by range location";
+const suggestedSpeciesKey = "suggested species by location";
 export default defineComponent({
   name: "SingleSpecieEditor",
   components: { SingleSpecieInfo },
@@ -88,7 +88,7 @@ export default defineComponent({
         { type: "subheader"; title: string } | Species
       > = [];
       if (inRangeSpecies.length > 0) {
-        result.push({ type: "subheader", title: "Suggested Species by Range Location" });
+        result.push({ type: "subheader", title: "Suggested Species by Location" });
         const sortedInRange = [...inRangeSpecies].sort((a, b) => {
           const aCat = categoryPriority[a.category] ?? 999;
           const bCat = categoryPriority[b.category] ?? 999;


### PR DESCRIPTION
USGS has some updates to the Suggested Location naming

- Quick rename to the label for the Species that are within a range on the client side
- some updates to some of the species names that were renamed or modified slightly

Everything should be referenced by foreign key so reingestion of the fixtures should update all existing annotations.
This would require a `manage.py loaddata species` again to update the fields.