### PR TITLE
Swap Pulse Metadata to text areas instead of maps

### DIFF
--- a/bats_ai/core/admin/pulse_metadata.py
+++ b/bats_ai/core/admin/pulse_metadata.py
@@ -1,12 +1,22 @@
 from __future__ import annotations
 
+from django import forms
 from django.contrib import admin
+from django.contrib.gis.db import models as gis_models
 
 from bats_ai.core.models import PulseMetadata
 
 
 @admin.register(PulseMetadata)
 class PulseMetadataAdmin(admin.ModelAdmin):
+    # Geometries are spectrogram coordinates, not geographic: avoid OpenLayers
+    # (projection/transform) and show WKT in a textarea instead.
+    formfield_overrides = {
+        gis_models.GeometryField: {
+            "widget": forms.Textarea(attrs={"rows": 4, "cols": 80}),
+        },
+    }
+
     list_display = [
         "recording",
         "index",


### PR DESCRIPTION
While the information for metadatas are saved as postgis geometry fields (for possible future filteirng/intersection) they have no definitive project.

There was a sentry error when attempting to view these using the openlayers default web interface.  Mostly because it was trying to convert to some sort of map project.  This swaps them to using Text fields for display in the admin itnerface instead.