### PR TITLE
remove the species shortcut

### DIFF
--- a/client/src/components/SingleSpecieEditor.vue
+++ b/client/src/components/SingleSpecieEditor.vue
@@ -6,8 +6,6 @@ import {
   ref,
   watch,
   type Ref,
-  onMounted,
-  onUnmounted,
 } from "vue";
 import type { Species } from "@api/api";
 import SingleSpecieInfo from "./SingleSpecieInfo.vue";

--- a/client/src/components/SingleSpecieEditor.vue
+++ b/client/src/components/SingleSpecieEditor.vue
@@ -115,15 +115,6 @@ export default defineComponent({
       );
     };
 
-    const speciesShortcut = (e: KeyboardEvent) => {
-      if (e.key === "S" && e.shiftKey) {
-        e.preventDefault();
-        speciesAutocomplete.value?.focus();
-      }
-    };
-    onMounted(() => window.addEventListener("keydown", speciesShortcut));
-    onUnmounted(() => window.removeEventListener("keydown", speciesShortcut));
-
     const onClearOrDeleteClick = () => {
       if (selectedCode.value) {
         selectedCode.value = null;


### PR DESCRIPTION
The Shift+S shortcut was causing some issues when entering text in different fields.  This removes that shortcut.