### PR TITLE
404 for not found recordings, allows none for compressed

### DIFF
--- a/bats_ai/core/views/nabat/nabat_recording.py
+++ b/bats_ai/core/views/nabat/nabat_recording.py
@@ -270,7 +270,7 @@ def get_spectrogram(request: HttpRequest, pk: int):
 
     spectrogram = nabat_recording.spectrograms.latest("created")
 
-    compressed = nabat_recording.compressed_spectrograms.latest("created")
+    compressed = nabat_recording.compressed_spectrograms.order_by("-created").first()
 
     spectro_data = {
         "urls": spectrogram.image_url_list,

--- a/bats_ai/core/views/recording.py
+++ b/bats_ai/core/views/recording.py
@@ -819,7 +819,7 @@ def get_spectrogram_compressed(request: HttpRequest, pk: int):
         CompressedSpectrogram.objects.filter(recording=pk).order_by("-created").first()
     )
     if compressed_spectrogram is None:
-        raise HttpError(404, f"Compressed spectrogram for recording {pk} not found")
+        raise Http404(404, f"Compressed spectrogram for recording {pk} not found")
 
     spectro_data = {
         "urls": compressed_spectrogram.image_url_list,

--- a/bats_ai/core/views/recording.py
+++ b/bats_ai/core/views/recording.py
@@ -10,9 +10,9 @@ from django.contrib.gis.geos import Point, Polygon
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.core.files.storage import default_storage
 from django.db.models import Count, Exists, OuterRef, Prefetch, Q, QuerySet
+from django.http import Http404
 from django.shortcuts import get_object_or_404
 from ninja import File, Form, Query, Schema
-from ninja.errors import HttpError
 
 # Django-Ninja accesses additional params directly, so we need to ignore the type checker.
 from ninja.files import UploadedFile  # noqa: TC002

--- a/bats_ai/core/views/recording.py
+++ b/bats_ai/core/views/recording.py
@@ -10,7 +10,9 @@ from django.contrib.gis.geos import Point, Polygon
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.core.files.storage import default_storage
 from django.db.models import Count, Exists, OuterRef, Prefetch, Q, QuerySet
+from django.shortcuts import get_object_or_404
 from ninja import File, Form, Query, Schema
+from ninja.errors import HttpError
 
 # Django-Ninja accesses additional params directly, so we need to ignore the type checker.
 from ninja.files import UploadedFile  # noqa: TC002
@@ -742,14 +744,10 @@ def get_recording_annotations(request: HttpRequest, recording_id: int):
 
 @router.get("/{pk}/spectrogram")
 def get_spectrogram(request: HttpRequest, pk: int):
-    try:
-        recording = Recording.objects.get(pk=pk)
-    except Recording.DoesNotExist:
-        return {"error": "Recording not found"}
+    recording = get_object_or_404(Recording, pk=pk)
 
     spectrogram = recording.spectrograms.latest("created")
-
-    compressed = recording.compressed_spectrograms.latest("created")
+    compressed = recording.compressed_spectrograms.order_by("-created").first()
 
     spectro_data = {
         "urls": spectrogram.image_url_list,
@@ -816,13 +814,12 @@ def get_spectrogram(request: HttpRequest, pk: int):
 
 @router.get("/{pk}/spectrogram/compressed")
 def get_spectrogram_compressed(request: HttpRequest, pk: int):
-    try:
-        recording = Recording.objects.get(pk=pk)
-        compressed_spectrogram = CompressedSpectrogram.objects.filter(recording=pk).first()
-    except compressed_spectrogram.DoesNotExist:
-        return {"error": "Compressed Spectrogram"}
-    except recording.DoesNotExist:
-        return {"error": "Recording does not exist"}
+    recording = get_object_or_404(Recording, pk=pk)
+    compressed_spectrogram = (
+        CompressedSpectrogram.objects.filter(recording=pk).order_by("-created").first()
+    )
+    if compressed_spectrogram is None:
+        raise HttpError(404, f"Compressed spectrogram for recording {pk} not found")
 
     spectro_data = {
         "urls": compressed_spectrogram.image_url_list,


### PR DESCRIPTION
resolves an issue where the variable names instead of the model classnames were being used for DoesNotExist

- Replaces the single `get` with `get_object_or_404`
-Previously for GET /recording/{pk}/spectrogram the latest would raise a DoesNotExist error if the compressed version didn't exists.  This allows the compressed version to not exist and for there to be a returned value missing the compressed references.   
for GET /`recording/{pk}/spectrogram/compressed` it will raise a 404 error if the compressed spectrogram doesn't exist.


Notes:

- There are multiple other places where I could replace `get()` with `get_object_or_404` but I didnt' want to make that significant of changes while we have an ongoing annotation task.  This can be done inbetween annotations tasks or in the future.
- The idea of spectrograms and compressed having multiple rows associated with a recording was from early on when we thought we would have multiple spectrogram types (outside of compressed and uncompressed).